### PR TITLE
SPP-1126 | Tooltip href fix 

### DIFF
--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,15 +1,18 @@
+@@ -1,15 +1,17 @@
 {{- $glossary := $.Site.GetPage "glossary" -}}
 {{- $tip := "" -}}
+{{- $link := "" -}}
 {{- $term := .Get 0 -}}
 {{- with $glossary -}}
     {{- range .Data.Pages -}}
         {{- if eq (lower .Title) (lower $term) -}}
             {{- $tip = .Content -}}
+            {{- $link = .RelPermalink -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- if $tip -}}
-<a class="tooltips-term">{{ $term }}{{with $tip }}<span class="tooltips-text">{{ . | plainify }}</span>{{ end }}</a>
+<a class="tooltips-term" href="{{ $link }}" >{{ $term }}{{ with $tip }}<span class="tooltips-text">{{ . | plainify }}</span>{{ end }}</a>
 {{- else -}}
 {{ $term }}
 {{- end -}}


### PR DESCRIPTION
### Tooltip href fix
---
Ticket: https://spandigital.atlassian.net/browse/SPP-1126
Tasks: Add the glossary item's url to the tooltip so the user can click on the tooltip and be redirected to the glossary item in the glossary section. 