### PR TITLE
fix | SPP-1258 | Update baseof html to use correct styling

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="{{ $.Site.BaseURL }}/media/images/favicon.ico" type="image/X-icon">
-    {{ hugo.Generator }}/
-    <link rel="stylesheet" href="{{ $.Site.BaseURL }}/presidium.css">
+    {{ hugo.Generator }}
+    {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    <link rel="stylesheet" href="{{ $style.Permalink }}">
     <title>{{ $.Site.Title }}</title>
 </head>
 <body>


### PR DESCRIPTION
### 
Update hugo theme website to use the correct sass files
---
**Ticket**: https://spandigital.atlassian.net/browse/SPP-1258
Solution: update the baseOf.html pipe in the header.
```
    {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
    <link rel="stylesheet" href="{{ $style.Permalink }}">
```

To test: 
1. Convert a site.
2. Perform the steps for Initializing Hugo's module system

```
cd ~/mycontendirectory
hugo mod init github.com/spandigital/mycontendirectory
hugo mod get -u
```
3. Add this line to the go.mod file of the converted site
```
replace github.com/spandigital/presidium-theme-website => /Users/[insert your own user name]/Documents/projects/presidium-theme-website

```
4. run  ```hugo mod get -u``` so it fetches the local theming. 
5. run ```hugo mod vendor```
6. See that in the _vendor folder baseOf.html has this in the header
```
    {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
    <link rel="stylesheet" href="{{ $style.Permalink }}">
```
7. Make a sass change somewhere in the ```_vendor/github.com/spandigital/presidium-theme-website/assets/_sass``` folder (e.g _tooltips.scss)
8. run ```hugo serve``` and see that a) it runs b) the styling change was made locally