### PR TITLE
Fix | SPP-1270 | Sections of the menu render twice

### DIFF
--- a/layouts/partials/json-navigation.html
+++ b/layouts/partials/json-navigation.html
@@ -1,8 +1,13 @@
 {{ $currentPage := . }}
 {{ $items := slice }}
 {{ $roles := slice }}
+{{ $urilzeIdentifier := slice }}
 {{ range $menu := .Site.Menus.main.ByWeight }}
-    {{ with $.Site.GetPage "section" $menu.Identifier }}
+    {{/* the menu Identifier has spaces such as "key concepts", need to add the dashes back using urilize
+     https://gohugo.io/functions/urlize/
+     */}}
+    {{ $urilzeIdentifier = $menu.Identifier | urlize  }}
+    {{ with $.Site.GetPage "section" $urilzeIdentifier }}
         {{ $items = $items | append (partial "json-nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" 1  "Roles" $roles )) }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
##
Sections of the menu render twice
---
**Ticket**: https://spandigital.atlassian.net/browse/SPP-1270
**Problem**: The GetPages section looks for pages with either 
a) one word  (e.g tools) or 
b) dash-separated words (e.g key-concepts)

Currently the menu.Identifier is using the title - the title has spaces (Key Concepts) and this is not recognized as a Page. So the sections with spaces are not being rendered. 

**Solution**
The original fix was to update the Identifier to use URL and not Title in configfile.go  see ticket  [here](https://spandigital.atlassian.net/browse/SPP-1147) 

This worked for all the sections, but then the default page was not being rendered (Overview) and another menu was appearing in its place. I reverted the change I made in the config.go on Presidium Hugo. 

And made a new fix for the sections not showing in this repo - this involved converting the Identifier string (Key Concepts) to dash-separated string in the spaces (using urlize)  -> now it will show as ```key-concepts``` 