### PR TITLE
SPP-1256 Tooltip with (# 'presidium-tooltip') renders random characters

### DIFF
--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,4 +1,3 @@
-@@ -1,15 +1,17 @@
 {{- $glossary := $.Site.GetPage "glossary" -}}
 {{- $tip := "" -}}
 {{- $link := "" -}}


### PR DESCRIPTION
When rendering tooltips @@ -1,15 +1,17 @@ gets prepended to the html.
![image](https://user-images.githubusercontent.com/5954878/105504316-49709500-5cd0-11eb-883f-1c140456b3c0.png)
