### PR TITLE
SPP-1208 | Generate media file containing paths to images for the giv…

### DIFF
--- a/layouts/_default/section.json
+++ b/layouts/_default/section.json
@@ -1,5 +1,5 @@
-{{ $articles := slice }}
-{{ range .Pages }}
-    {{ $articles = $articles | append (dict "path" .File.Path) }}
+{{ $media := slice }}
+{{ range .Resources.ByType "image" }}
+    {{ $media = $media | append (dict "path" .RelPermalink) }}
 {{ end }}
-{{ dict "articles" $articles | jsonify }}
+{{ dict "media" $media | jsonify }}


### PR DESCRIPTION
Generate media file containing paths to images for the given directory.  This is used by the editor to display an image file browser when editing images for articles.

The file will look like this:

```
{
    "media": [
        {
            "path": "/docs/uploads-span-handbook/business-operations/SPAN-POL-002-Quality-System-Policy.png"
        },
        {
            "path": "/docs/uploads-span-handbook/business-operations/SPAN-PRO-007-Quality-System-Review-Procedure.png"
        }
    ]
}
```