### PR TITLE
Fix | PRS-1581 | Article status missing

### DIFF
--- a/layouts/partials/status.html
+++ b/layouts/partials/status.html
@@ -1,7 +1,7 @@
-{{ if or (.Site.Params.show.status) (not (isset .Site.Params.show "status")) }}
+{{ if .Site.Params.showStatus }}
     {{ if .Params.status }}
         <div class="article-status">
-            {{ $status := .Params.status}}
+            {{ $status := lower .Params.status}}
             {{ if eq $status "draft" }}
                 <span title="Article Status" class="label label-default status-draft">Draft</span>
             {{ else if eq $status "review" }}


### PR DESCRIPTION
### Update Status HTML to show statuses
**Ticket**: https://spandigital.atlassian.net/browse/PRS-1581
Issue: Status of the articles were not showing when show status was set to true and when front matter set a status on an article 