### PR TITLE
Fix | PRS-1584 | Collapsed menu items

### DIFF
--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -12,22 +12,25 @@
 {{if not .NavPage.Data.Pages }}
     {{ $link = (printf "%v#%v" .NavPage.Parent.RelPermalink .NavPage.Params.Slug ) }}
 {{end}}
+{{ $collapsed := .Collapsed }}
 <li class="menu-parent_{{ .NavPage.Slug }}{{if $onArticle}} on-article{{end}}{{if $expanded}} expanded{{end}} ">
     <div class="menu-row {{ $cssClass }}">
-        <div class="menu-expander">
-            {{ if .NavPage.Data.Pages }}
-                {{ if $expanded }}
-                    <span class="glyphicon glyphicon-chevron-down"></span>
-                {{ else }}
-                    <span class="glyphicon glyphicon-chevron-right"></span>
+        {{ if not $collapsed }} 
+            <div class="menu-expander">
+                {{ if .NavPage.Data.Pages }}
+                    {{ if $expanded }}
+                        <span class="glyphicon glyphicon-chevron-down"></span>
+                    {{ else }}
+                        <span class="glyphicon glyphicon-chevron-right"></span>
+                    {{ end }}
                 {{ end }}
-            {{ end }}
-        </div>
+            </div>
+        {{ end }}
         <div class="menu-title">
             <a data-slug="{{ .NavPage.Slug }}" data-id="{{ .NavPage.File.Filename }}" href="{{ $link }}">{{ .NavPage.Name }}</a>
         </div>
     </div>
-    {{ if .NavPage.Data.Pages }}
+    {{ if and (.NavPage.Data.Pages) (not $collapsed)  }}
         <ul class="dropdown {{if $expanded}}expanded{{ else }}hidden{{end}}">
             {{ range .NavPage.Data.Pages }}
                 {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" $childLevel) }}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -29,7 +29,7 @@
             <ul>
                 {{ range $menu := .Site.Menus.main.ByWeight }}
                     {{ with $.Site.GetPage "section" $menu.Identifier }}
-                        {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" 1 "Expanded" true) }}
+                        {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed) }}
                     {{ end }}
                 {{ end }}
 


### PR DESCRIPTION
### Create the ability to collapse menu items in the config file

**Ticket**: https://spandigital.atlassian.net/browse/PRS-1584

**Note**: The hugo converter will need a new Params in the menu 

```
menu:
  Main:
  - identifier: Overview
    name: Overview
    url: /
    weight: 1
 
```

**After**

```
menu:
  Main:
  - identifier: Overview
    name: Overview
    url: /
    weight: 1
    params: 
      collapsed: true
```