### PR TITLE
Fixed tooltip shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 static/node_modules
+.idea/
+resources/

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -5,8 +5,12 @@
 {{ if $ref }}
     {{ $page = .Site.GetPage $ref }}
 {{ else }}
-    {{ range where (where .Site.Pages "Section" "glossary") "Title" "=" $title }}
-        {{ $page = . }}
+    {{ range where .Site.Pages "Section" "glossary" }}
+        {{ $GlossaryTitle := lower .Title }}
+        {{ $TooltipTitle := lower $title }}
+        {{ if eq $GlossaryTitle $TooltipTitle }}
+            {{ $page = . }}
+        {{ end }}
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
I changed the tooltip shortcode to make case insensitive comparisons between the tooltip and the glossary titles. The history page is now rendering:
![Screenshot 2021-09-22 at 09 51 31](https://user-images.githubusercontent.com/4488721/134304162-7b784045-976c-4291-bdb2-51f4fee22b1f.png)
 