### PR TITLE
Fix broken tooltip rendering on site,

### DIFF
--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -2,16 +2,17 @@
 {{ $ref := .Get 1}}
 {{ $page := "" }}
 
+
 {{ if $ref }}
     {{ $page = .Site.GetPage $ref }}
 {{ else }}
+
     {{ range where .Site.Pages "Section" "glossary" }}
-        {{ $GlossaryTitle := lower .Title }}
-        {{ $TooltipTitle := lower $title }}
-        {{ if eq $GlossaryTitle $TooltipTitle }}
+        {{ if eq (lower .Title) (lower $title) }}
             {{ $page = . }}
         {{ end }}
     {{ end }}
+
 {{ end }}
 
 {{ if $page }}
@@ -19,5 +20,9 @@
         {{ $title }}<span class="tooltips-text">{{ $page.Content | truncate 100 | plainify }}</span>
     </a>
 {{ else }}
-    {{ errorf "Wrong document provided: %s in %s" $ref .Page.File }}
+    {{ if $ref }}
+        {{ errorf "Error rending tooltip at href [%s] in file [%s]" $ref .Page.File }}
+    {{else}}
+        {{ errorf "Error rending tooltip with title [%s] in file [%s]" $title .Page.File }}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
# What changed

- Shortcode template matches tooltip with glossary page indpendant of character case.
- Improved error emitted to hugo while rendering site.