### PR TITLE
fix(list): moved index content to the top

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,6 @@
 {{ define "content" }}
-
+    {{ .Content }}
+    
     {{ $site_scopes := .Site.Data.scopes.applied }}
     {{ $site_scopes_enabled := .Site.Data.scopes.enabled }}
     {{ $pages := .Data.Pages }}


### PR DESCRIPTION
### Description
Content in index files are displayed at the bottom instead of the top

