### PR TITLE
fix(article): relative article paths

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -4,11 +4,12 @@
 {{if not .Data.Pages }}
     {{ $type = "child" }}
 {{end}}
+{{ $dataId := .Params.id | default .File.Path }}
 {{ $pageSlug := (printf "%v-%v" (.Parent.Params.Slug | default "root") .Params.Slug )}}
 <div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $pageSlug }}">
 <!--<div class="article" data-roles="{{ $roles }}" id="{{ $link }}">-->
     <div class="presidium-article-wrapper">
-        <span class="anchor"  id="{{ .Params.Slug }}" data-id="{{ with .File }}{{ .Filename }}{{ end }}"></span>
+        <span class="anchor"  id="{{ .Params.Slug }}" data-id="{{ $dataId }}"></span>
         <div class="article-title" >
             {{ if not .Data.Pages }}
                 <h2>{{ .Title }} {{ partial "edit-link.html" }}</h2>

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -14,10 +14,10 @@
 {{if not .NavPage.Data.Pages }}
     {{ $link = (printf "%v#%v" .NavPage.Parent.Permalink .NavPage.Params.Slug ) }}
 {{end}}
-
+{{ $dataId :=  .NavPage.Params.id | default  .NavPage.File.Path }}
 {{ $state := cond $isParent "open" "closed" }}
 <li class="menu-row menu-parent_{{ .NavPage.Parent.Slug }} collapse {{ if $showMenu }}in{{end}} {{ if $canExpand}}{{$state}}{{end}} {{ if $isChild }}child{{end}}" style="overflow: hidden;{{ if not $showMenu }}height: 0;{{ end }}">
-    <a class="{{ if eq .Index 0 }}first-child{{end}} {{ $cssClass }}" data-slug="{{ .NavPage.Slug }}" data-target="#{{$pageSlug}}"  data-id="{{ .NavPage.File.Filename }}" href="{{ $link }}">
+    <a class="{{ if eq .Index 0 }}first-child{{end}} {{ $cssClass }}" data-slug="{{ .NavPage.Slug }}" data-target="#{{$pageSlug}}"  data-id="{{ $dataId }}" href="{{ $link }}">
         {{ if .NavPage.Data.Pages }}
             <div class="menu-expander" data-toggle="collapse" data-target=".menu-parent_{{ .NavPage.Slug }}" aria-controls=".menu-parent_{{ .NavPage.Slug }}">
                 {{ if $isParent }}


### PR DESCRIPTION
### Description

Article paths are currently absolute, so if the site is built from a different directory all articles ID's will change. The new article path will be relative to the content root see below:

Current path:
```
/Users/meyer/Documents/Workspace/Span/sites/span-handbook-hugo/content/introduction/overview.md
```
New path:
```
introduction/overview.md
```

I also added an option to override the article ID so that they can be preserved during conversion. If the article has and `Id` specified in the front matter the template will use that instead of the current file path. 
