### PR TITLE
fix(scrollspy): use article title to calculate scroll offset

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -65,7 +65,7 @@
             $('.navbar-items').toggle('expanded');
         });
 
-        const content = $('.page-title').get(0)
+        const content = $('.article-title').get(0)
         if (content) { 
             const offset = window.pageYOffset + content.getBoundingClientRect().top; 
             $('[data-spy]').attr('data-offset', offset);


### PR DESCRIPTION
### Description
The scrollspy offset is not working for all sites, for small articles the wrong menu item is highlighted

![Screenshot 2022-02-01 at 15 22 18](https://user-images.githubusercontent.com/48946187/151982460-24e03e02-3e9b-41b6-80cc-29ee16441f29.png)
