### PR TITLE
fix/PRSDM-1833-favicon-for-docs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,3 +16,6 @@ module:
       target: archetypes
     - source: node_modules
       target: static/node_modules
+
+params:
+  favicon: images/favicon.ico

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
     <title>{{ $.Site.Title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ hugo.Generator }}
-    <link rel="shortcut" href="{{ .Site.Params.favIcon | absURL }}" type="image/png">
+    <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">
     {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
     {{ if resources.Get "index.scss"  }}


### PR DESCRIPTION
Fixes baseof.html <link> tag for the favicon and updates config.yml to add the params that the <link> tag uses