### PR TITLE
fix/PRSDM-1927-broken-images

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -79,7 +79,6 @@
         }
         
         $(window).scroll(function scrollspyOffset(window) {
-            console.log('bar offset:', bar_offset);
             if(window.scrollTop() >= offset){
                 $('body').data()['bs.scrollspy'].options.offset = (60 + bar_offset);
             }

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,9 +1,13 @@
 {{ $src := .Get "src" }}
 {{ $url := urls.Parse $src }}
-{{ if .Page.Resources.GetMatch $src }}
-    {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.RelPermalink | default "") $src }}
-{{ else if .Page.Parent.Resources.GetMatch $src }}
+{{ $src = strings.TrimPrefix "/" $src }}
+
+{{ if .Page.Parent.Resources.GetMatch $src }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.RelPermalink | default "") $src }}
+    <p>{{printf "Page match: %v" $src}}</p>
+{{ else if .Page.Parent.Parent.Resources.GetMatch $src }}
+    {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.Parent.RelPermalink | default "") $src }}
+    <p>{{printf "Parent: %v" $src}}</p>
 {{ else if not $url.Scheme  }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) $src }}  
 {{ end }}


### PR DESCRIPTION
Fix broken images

### Description
Updated img shortcode since the previous fix wasn't working. For some reason Hugo is mistaking `.Parent` as the current directory not the actual parent. The prefix `/` also had to be removed for the if statements to work and get a match.
Also removed a `console.log` accidentally left in from scrollspy testing.

### Issue
[<!-- JIRA link -->](https://spandigital.atlassian.net/jira/software/projects/PRSDM/boards/100?selectedIssue=PRSDM-1927)

### Testing
In the handbook go to business-operations -> productivity-tools -> harvest since multiple images were broken on that page. Also tested to make sure external url images are working by adding one and making sure it rendered.

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
