### PR TITLE
fix(logo): use logo from params if set

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -7,8 +7,8 @@
         <div class="navbar-header">
             <a href="{{ .Site.BaseURL }}" class="brand">
                 {{ $navImg := (printf "%s%s" .Site.BaseURL "images/logo.png") }}
-                {{ if fileExists "static/brand/images/logo.png" }}
-                {{ $navImg = "brand/images/logo.png" | relURL }}
+                {{ if .Site.Params.logo }}
+                {{ $navImg = .Site.Params.logo }}
                 {{ end }}
                 <img src={{ $navImg }} alt="Logo image">
             </a>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
The logo param in the config.yml was not loaded

### Issue
[PRS-1919](https://spandigital.atlassian.net/browse/PRSDM-1919)

### Testing
- Convert the site and make sure the Span Handbook logo is showing instead of the presidium logo

### Checklist before merging
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?


### [Notes](#notes)
The logo is showing now but the logo dimensions are not the same as the original site, this is because the custom styles still need to be fixed. I added a ticket to fix the custom styles https://spandigital.atlassian.net/browse/PRSDM-1954
