### PR TITLE
fix/PRSDM-1924-github-author

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -2,10 +2,10 @@
     {{ if .Params.author }}
         {{ $authorLabel := .Site.Params.author.label | default "Author" }}
         {{ if .Params.author }}
-            {{ $authorLink := .Params.author }}
+            {{ $authorLink := .Params.github }}
             {{ $newTab := .Site.Params.author.external.newTab }}
             <div class="article-author">
-                {{ $authorLabel }}: <a href="{{ $authorLink }}{{ .Params.author }}" target="{{ if $newTab }} _blank {{ end }}">{{ .Params.author }}</a>
+                {{ $authorLabel }}: <a href="https://github.com/{{ $authorLink }}" target="{{ if $newTab }} _blank {{ end }}">{{ .Params.author }}</a>
             </div>
         {{ else }}
             <div class="article-author">


### PR DESCRIPTION
Fixed author not found when clicking author link

### Description
Author link now redirects to github correctly

### Issue
[<!-- JIRA link -->](https://spandigital.atlassian.net/jira/software/projects/PRSDM/boards/100?selectedIssue=PRSDM-1924)

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
