### PR TITLE
fix(logo): add baseurl to logo path

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -8,7 +8,7 @@
             <a href="{{ .Site.BaseURL }}" class="brand">
                 {{ $navImg := (printf "%s%s" .Site.BaseURL "images/logo.png") }}
                 {{ if .Site.Params.logo }}
-                {{ $navImg = .Site.Params.logo }}
+                {{ $navImg =  (printf "%s%s" .Site.BaseURL .Site.Params.logo) }}
                 {{ end }}
                 <img src={{ $navImg }} alt="Logo image">
             </a>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Fixed logo path to append the baseurl

### Issue
[PRS_1957](https://spandigital.atlassian.net/browse/PRSDM-1957)

### Testing
- Checkout the latest version of the theme
- Link it to the Span Hanbook
- Make sure the Span Handbook logo is showing

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
