### PR TITLE
Filter articles based on role

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <title>{{ $.Site.Title }}</title>
@@ -8,102 +9,142 @@
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">
     {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
-    {{ if resources.Get "index.scss"  }}
-        {{ with resources.Get "index.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
-            <link rel="stylesheet" href="{{ .Permalink }}">
-        {{ end }}
+    {{ if resources.Get "index.scss" }}
+    {{ with resources.Get "index.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    <link rel="stylesheet" href="{{ .Permalink }}">
+    {{ end }}
     {{ end }}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
 
 </head>
+
 <body>
-{{ if $.Site.Params.enterprise_enabled }}
-    <div data-key="{{ $.Site.Params.enterprise_key }}"
-         data-title="{{ $.Site.Title }}"
-         id="presidium-enterprise"
-         class="presidium-enterprise">
+    {{ if $.Site.Params.enterprise_enabled }}
+    <div data-key="{{ $.Site.Params.enterprise_key }}" data-title="{{ $.Site.Title }}" id="presidium-enterprise"
+        class="presidium-enterprise">
     </div>
-{{ end }}
+    {{ end }}
 
-<div id="presidium-navigation">
-    {{ partial "navigation.html" .}}
-</div>
-<div id="presidium-container" class="container-fluid">
-    <div class="row">
-        <div id="presidium-content" class="col-lg-10 col-md-12">
-            <h1 class="page-title">{{ .Title }}</h1>
-            <hr/>
+    <div id="presidium-navigation">
+        {{ partial "navigation.html" .}}
+    </div>
+    <div id="presidium-container" class="container-fluid">
+        <div class="row">
+            <div id="presidium-content" class="col-lg-10 col-md-12">
+                <h1 class="page-title">{{ .Title }}</h1>
+                <hr />
 
-            <section>
-                {{ partial "info.html" }}
-                {{ block "content" . }}
-                {{ end }}
-                {{ .Content }}
-            </section>
-            {{ partial "footer.html" . }}
+                <section>
+                    {{ partial "info.html" }}
+                    {{ block "content" . }}
+                    {{ end }}
+                    {{ .Content }}
+                </section>
+                {{ partial "footer.html" . }}
+            </div>
+            <div class="col-lg-2"></div>
         </div>
-        <div class="col-lg-2"></div>
     </div>
-</div> <!--presidium-container-->
+    <!--presidium-container-->
 
-{{ partial "modal.html" }}
+    {{ partial "modal.html" }}
 
-<script>
-    $( document ).ready(function() {
-        $('.menu-expander').click(function (event) {
-            event.preventDefault();
-            if (this.firstElementChild) {
-                this.firstElementChild.classList.toggle('glyphicon-chevron-down');
-                this.firstElementChild.classList.toggle('glyphicon-chevron-right');
+    <script>
+        $(document).ready(function () {
+            $('.menu-expander').click(function (event) {
+                event.preventDefault();
+                if (this.firstElementChild) {
+                    this.firstElementChild.classList.toggle('glyphicon-chevron-down');
+                    this.firstElementChild.classList.toggle('glyphicon-chevron-right');
+                }
+                $(this).parent().closest('.menu-row').toggleClass('open').toggleClass('closed');
+            });
+
+            $('.toggle').click(function (event) {
+                event.preventDefault();
+                $('.navbar-items').toggle('expanded');
+            });
+
+            // Set scrollspy offset
+            let offset = 0;
+            const content = $('.article-title').get(0);
+            if (content) {
+                offset = window.pageYOffset + content.getBoundingClientRect().top;
+                $('body').scrollspy({ target: '#presidium-navigation', offset: offset });
             }
-            $(this).parent().closest('.menu-row').toggleClass('open').toggleClass('closed');
-        });
-
-        $('.toggle').click(function (event) {
-            event.preventDefault();
-            $('.navbar-items').toggle('expanded');
-        });
-
-        // Set scrollspy offset
-        let offset = 0;
-        const content = $('.article-title').get(0);
-        if (content) { 
-            offset = window.pageYOffset + content.getBoundingClientRect().top;
-            $('body').scrollspy({target: '#presidium-navigation', offset:offset});
-        }
-        let bar_offset = 0;
-        const enterprise_bar = $('#presidium-enterprise-toolbar').get(0);
-        if (enterprise_bar) {
-            bar_offset = enterprise_bar.getBoundingClientRect().height;
-        }
-        
-        $(window).scroll(function scrollspyOffset(window) {
-            if(window.scrollTop() >= offset){
-                $('body').data()['bs.scrollspy'].options.offset = (60 + bar_offset);
+            let bar_offset = 0;
+            const enterprise_bar = $('#presidium-enterprise-toolbar').get(0);
+            if (enterprise_bar) {
+                bar_offset = enterprise_bar.getBoundingClientRect().height;
             }
-            else {
-                $('body').data()['bs.scrollspy'].options.offset = offset; 
+
+            $(window).scroll(function scrollspyOffset(window) {
+                if (window.scrollTop >= offset) {
+                    $('body').data()['bs.scrollspy'].options.offset = (60 + bar_offset);
+                }
+                else {
+                    $('body').data()['bs.scrollspy'].options.offset = offset;
+                }
+                $('body').data()['bs.scrollspy'].process();
+                $('body').scrollspy("refresh");
+            });
+
+
+            // filter articles and navigation when role changes
+            const filterArticles = (selectedRole) => {
+                sessionStorage.setItem('role', selectedRole);
+                $('.article').show()
+                $('#presidium-navigation .menu-row').removeClass('hidden').show()
+                if (selectedRole != 'All Roles') {
+                    const $articles = $(`.article:not([data-roles="All Roles"],[data-roles="${selectedRole}"])`)
+                    $articles.each((i, article) => {
+                        $(article).hide();
+                        $(`#presidium-navigation .menu-row>a[data-target="#${article.id}"]`)
+                            .parent()
+                            .addClass('hidden')
+                            .hide();
+                    });
+    
+                    $('#presidium-navigation .menu-row').each((_, e) => {
+                        const $row = $(e)
+                        const $children = $row.find('ul>li.menu-row');
+                        const $active = $children.filter(':not(.hidden)');
+                        if ($active.length == 0 && $children.length > 0) {
+                            $row.hide();
+                        }
+                    });
+                }
+            };
+    
+            const lastRole = sessionStorage.getItem('role');
+            if (lastRole) {
+                $('#roles-select').val(lastRole);
+                filterArticles(lastRole);
             }
-            $('body').data()['bs.scrollspy'].process();
-            $('body').scrollspy("refresh");
+    
+            $('#roles-select').on('change', function (e) {
+                const optionSelected = $("option:selected", this);
+                const selectedRole = this.value;
+                filterArticles(selectedRole);
+            });
         });
-    });
-</script>
+    </script>
 
-<!-- Components -->
-<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-<script src="/presidium.js"></script>
-<script>
-    window.presidium.tooltips = {};
-    window.presidium.tooltips.load = function (data) {};
-    window.presidium.articles.mount();
-    mermaid.initialize({startOnLoad:true});
-</script>
+    <!-- Components -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <script src="/presidium.js"></script>
+    <script>
+        window.presidium.tooltips = {};
+        window.presidium.tooltips.load = function (data) { };
+        window.presidium.articles.mount();
+        mermaid.initialize({ startOnLoad: true });
+    </script>
 
-{{ if $.Site.Params.enterprise_enabled }}
-<script src="{{ $.Site.Params.enterprise_script }}"></script>
-{{ end }}
+    {{ if $.Site.Params.enterprise_enabled }}
+    <script src="{{ $.Site.Params.enterprise_script }}"></script>
+    {{ end }}
 
 </body>
+
 </html>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,4 +1,4 @@
-{{ $roles := .Params.roles | default "All roles" }}
+{{ $roles := .Params.roles | default "All Roles" }}
 {{ $link := (printf "%v#%v" .Parent.Permalink .Params.Slug ) }}
 {{ $type := "parent" }}
 {{if not .Data.Pages }}

--- a/layouts/partials/json-navigation.html
+++ b/layouts/partials/json-navigation.html
@@ -15,4 +15,4 @@
 {{ with $.Site.Params.logo }}
     {{ $logo =  $.Site.Params.logo | relURL }}
 {{ end }}
-{{ return ( dict "logo" $logo "brandName" $.Site.Title "brandUrl" "" "baseUrl" (relURL "/") "roles" (dict "label" "Display documentation for" "all" "All roles" "options" $roles ) "children" $items) }}
+{{ return ( dict "logo" $logo "brandName" $.Site.Title "brandUrl" "" "baseUrl" (relURL "/") "roles" (dict "label" "Display documentation for" "all" "All Roles" "options" $roles ) "children" $items) }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
There was no logic in the theme to filter articles when a role is selected. 

### Issue
[PRS-1972](https://spandigital.atlassian.net/browse/PRSDM-1972)

### Testing
- Add a role in the front matter of an article e.g. `roles: Engineering`
- When you switch the role filter it should hide all articles and menu items that don't belong to that role.
- When all menu items within a section are hidden the parent section should also be hidden.
- When you reload the page the last role that was applied should show.

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [ ] Did you test your changes locally?
