### PR TITLE
fix(menu): anchorize menu identifier

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -53,8 +53,8 @@
                             {{ if $menu.Params.externalUrl}}
                             {{ partial "nav-item-external" $menu }}
                         {{ else }}
-                            {{ $identifier := replace $menu.Identifier " " "-"}}
-                            {{ with $.Site.GetPage "section" $identifier }}
+                            {{ $identifier := anchorize $menu.Identifier }}
+                            {{ with $.Site.GetPage $identifier }}
                                 {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed  "RootUrl" $rootUrl "Show" false) }}
                             {{ end }}
                         {{ end }}                    


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
The main issue with the menu has been fixed in the [converter](https://github.com/SPANDigital/presidium-hugo/pull/101). This PR just updates the menu identifier for backward compatibility so we don't break the Span Handbook 

### Issue
[PRS-2022](https://spandigital.atlassian.net/browse/PRSDM-2022)

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [ ] Did you test your changes locally?
