### PR TITLE
fix/PRSDM-2057-hashlink-offset

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -59,6 +59,10 @@
           top: -10px;
         }
       }
+      span.anchor-enterprise{
+        top: -50px;
+      }
+
 
       .article-title {
         display: flex;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -76,6 +76,10 @@
             const enterprise_bar = $('#presidium-enterprise-toolbar').get(0);
             if (enterprise_bar) {
                 bar_offset = enterprise_bar.getBoundingClientRect().height;
+                // Update offset after linking
+                $('span.anchor').each(function(){
+                    $(this).addClass('anchor-enterprise');
+                });
             }
 
             $(window).scroll(function() {


### PR DESCRIPTION
Enterprise bar was hiding the article title after linking to it

### Description
Added css class to account for the extra height of the enterprise bar and some jquery to apply this class to the span anchor when the enterprise bar exists.

### Issue
[JIRA link](https://spandigital.atlassian.net/jira/software/projects/PRSDM/boards/100?selectedIssue=PRSDM-2057)

### Testing
Click on links and make sure the enterprise bar doesn't hide the article titles

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
