### PR TITLE
Reduce specificity to allow overriding nav border

### DIFF
--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -10,6 +10,23 @@ $nav-item-border: darken($navbar-default-bg, 8%);
   }
 }
 
+// Custom SASS
+@mixin bg-gradient($color) {
+  // Mixin below comes from bootstrap
+  @include gradient-vertical-three-colors(
+    lighten($color, 15%),
+    $color,
+    50%,
+    darken($color, 4%)
+  );
+  filter: none;
+  border: 1px solid darken($color, 10%);
+}
+
+.scrollable-container {
+  @include bg-gradient($navbar-default-bg);
+}
+
 #presidium-navigation {
   position: relative;
 
@@ -90,8 +107,6 @@ $nav-item-border: darken($navbar-default-bg, 8%);
       overflow-y: auto;
       height: 100%;
     }
-    filter: none;
-    border: 1px solid darken($navbar-default-bg, 10%);
   }
 
   nav {


### PR DESCRIPTION
Linked to bootswatch removal:  https://github.com/SPANDigital/presidium-theme-website/pull/98/files 
This is an amendment fix to that PR

### Description
The border being applied to the navbar in presidium handbook docs is using an id + class selector which gives it a higher specificity. The consequence of this is that it prevents the apple theme from overriding the border in their own sites. This PR fixes that issue 

### Issue
[PRSDM-2038](https://spandigital.atlassian.net/browse/PRSDM-2038)

### Testing
<!-- Provide QA steps -->

### Screenshots

![Screenshot 2022-04-12 at 11 32 56 PM](https://user-images.githubusercontent.com/41419154/163058376-8bab8179-cef2-4a8b-a27b-2f07cde17ac0.png)

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [ ] Did you test your changes locally?
