### PR TITLE
fix overflow issue in apple sidebar navigation

### DIFF
--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -324,6 +324,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
 
       .menu-title {
         flex: 1;
+        word-break: normal;
         @media (max-width: $grid-float-breakpoint) {
           font-size: 16px;
         }


### PR DESCRIPTION
The sidebar navigation panel text was not overflowing as intended, changed it so that the entire word breaks onto the next line instead of a portion of the letters. 

### Issue
[PRSDM-2102](https://spandigital.atlassian.net/browse/PRSDM-2102)

### Screenshots

![Screenshot 2022-04-13 at 10 58 19 PM](https://user-images.githubusercontent.com/41419154/163269280-52cb2cb5-39e8-465b-a901-5047dab39315.png)

![Screenshot 2022-04-13 at 10 59 06 PM](https://user-images.githubusercontent.com/41419154/163269401-f4aee676-422b-4f48-a23f-ed20f78ce263.png)


