### PR TITLE
fix/PRSDM-2129-duplicate-overview

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,6 +5,8 @@
     {{ $siteScopes := .Site.Params.scopes }}
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
     {{ $pages := .Data.Pages }}
+    
+    {{ $index := 0 }}
   
     {{ range .Data.Pages.ByWeight }}
 
@@ -18,8 +20,11 @@
         {{ end }}
 
         {{ if $isRendering }}
+            {{ .Scratch.Set "index" $index }}
             {{ partial "article" . }}
         {{ end }}
+
+        {{ $index = add $index 1 }}
 
     {{ end }}
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -20,11 +20,15 @@
 {{ $pageSlug := (printf "%v-%v" ($parentSlug) $slug )}}
 {{ $nestedArticles := .Site.Params.includeNestedArticles | default true }}
 
+{{ $index := .Scratch.Get "index" }}
+
 <div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $pageSlug }}">
     {{ if or (ne (len .Content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $dataId }}"></span>
-        {{ if ne .Parent.Title .Title}}
+        {{ if and (eq .Parent.Title .Title) (eq $index 0) }}
+            {{/*  No title - For when the main title is the same as the first article  */}}
+        {{ else }}
             <div class="article-title" >
                 {{ if not .Data.Pages }}
                     <h2>{{ .Title }} {{ partial "edit-link.html" }}</h2>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -25,7 +25,8 @@
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $dataId }}"></span>
         <div class="article-title" >
-            {{ if not .Data.Pages }}
+            {{ if eq .Parent.Title .Title}}
+            {{ else if not .Data.Pages }}
                 <h2>{{ .Title }} {{ partial "edit-link.html" }}</h2>
             {{ else }}
                 <h1>{{ .Title }} {{ partial "edit-link.html" }}</h1>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -24,18 +24,19 @@
     {{ if or (ne (len .Content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $dataId }}"></span>
-        <div class="article-title" >
-            {{ if eq .Parent.Title .Title}}
-            {{ else if not .Data.Pages }}
-                <h2>{{ .Title }} {{ partial "edit-link.html" }}</h2>
-            {{ else }}
-                <h1>{{ .Title }} {{ partial "edit-link.html" }}</h1>
-            {{ end }}
-           
-            <div class="permalink">
-                <a class="link-icon" href="#{{ $slug }}" title="Permalink to this article"></a>
+        {{ if ne .Parent.Title .Title}}
+            <div class="article-title" >
+                {{ if not .Data.Pages }}
+                    <h2>{{ .Title }} {{ partial "edit-link.html" }}</h2>
+                {{ else }}
+                    <h1>{{ .Title }} {{ partial "edit-link.html" }}</h1>
+                {{ end }}
+                
+                <div class="permalink">
+                    <a class="link-icon" href="#{{ $slug }}" title="Permalink to this article"></a>
+                </div>
             </div>
-        </div>
+        {{ end }}
 
         {{ partial "article-header" . }}
 

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -73,7 +73,9 @@
     {{ if and (.NavPage.Data.Pages) }}
         <ul>
         {{ range $index, $subMenu := .NavPage.Data.Pages }}
-            {{ if and (not $subMenu.Params.hidden) (ne .Title .Parent.Title) }}
+            {{ if and (eq .Parent.Title .Title) (eq $index 0) }}
+                {{/*  No link needed - For when the main title is the same as the first article  */}}
+            {{ else if not $subMenu.Params.hidden }}
                  {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
             {{ end }}
         {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -73,7 +73,7 @@
     {{ if and (.NavPage.Data.Pages) }}
         <ul>
         {{ range $index, $subMenu := .NavPage.Data.Pages }}
-            {{ if not $subMenu.Params.hidden }}
+            {{ if and (not $subMenu.Params.hidden) (ne .Title .Parent.Title) }}
                  {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
Stopped there being a title directly below the page title if they are the same

### Description
If the title, in this case Overview, is the same as the 'page-title' then it will not render the title, only the page-title. It will also be removed from the menu

### Issue
[PRSDM-2129](https://spandigital.atlassian.net/jira/software/projects/PRSDM/boards/100?selectedIssue=PRSDM-2129)

### Testing
Go to the Overview section in Alpine Search docs and make sure only the page-title "Overview" is shown and the child menu item "Overview" is not present.

### Screenshots
![What it should look like](https://user-images.githubusercontent.com/12759737/164074311-41f6d5d3-8872-4f91-b23d-3ea7d5156b44.png)


### Checklist before merging
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
