### PR TITLE
fix to hide/show profile image in article comments

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -62,8 +62,8 @@
             $('.toggle').click(function (event) {
                 event.preventDefault();
                 $('.navbar-items').toggle('expanded');
-            });       
-            
+            });
+
         });
     </script>
 
@@ -79,7 +79,7 @@
 
     {{ if $.Site.Params.enterprise_enabled }}
     <script src="{{ $.Site.Params.enterprise_script }}"></script>
-    <script src="../conf/config.js"></script>
+    <script src="/conf/config.js"></script>
     {{ end }}
 
 </body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -79,6 +79,7 @@
 
     {{ if $.Site.Params.enterprise_enabled }}
     <script src="{{ $.Site.Params.enterprise_script }}"></script>
+    <script src="../conf/config.js"></script>
     {{ end }}
 
 </body>


### PR DESCRIPTION
Description:
The config file that sets whether a profile image should be shown or not was not being loaded into the presidium docs index.html file and therefore it was unable to honour the config settings. Linking it fixes the problem. 

### Issue
Jira ticket link:  https://spandigital.atlassian.net/browse/PRSDM-426

