### PR TITLE
PRSDM-dashed-link-fix

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,13 +1,15 @@
 {{ $roles := .Params.roles | default "All Roles" }}
 
 {{/* Use title if no slug */}}
-{{ $slug := anchorize .Params.Title }}
+{{ $slug := humanize .Params.Title }} {{/* Handles any dashes in the title */}}
+{{ $slug = anchorize $slug }}
 {{ if .Params.Slug }}
     {{ $slug = .Params.Slug}}
 {{ end }}
 
 {{/* Parent slug */}}
-{{ $parentSlug := ((anchorize .Parent.Params.Title) | default "root") }}
+{{ $parentSlug := ((humanize .Parent.Params.Title) | default "root") }}
+{{ $parentSlug = anchorize $parentSlug }}
 {{ if .Parent.Params.Slug }}
     {{ $parentSlug = .Parent.Params.Slug}}
 {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -31,13 +31,15 @@
 {{ $isChild := not $isParent }}
 
 {{/* Use title if no slug */}}
-{{ $slug := anchorize .NavPage.Params.Title }}
+{{ $slug := humanize .NavPage.Params.Title }} {{/* Handles any dashes in the title */}}
+{{ $slug = anchorize $slug }}
 {{ if .NavPage.Params.Slug }}
     {{ $slug = .NavPage.Params.Slug}}
 {{ end }}
 
 {{/* Parent slug */}}
-{{ $parentSlug := ((anchorize .NavPage.Parent.Params.Title) | default "root") }}
+{{ $parentSlug := ((humanize .NavPage.Parent.Params.Title) | default "root") }}
+{{ $parentSlug = anchorize $parentSlug }}
 {{ if .NavPage.Parent.Params.Slug }}
     {{ $parentSlug = .NavPage.Parent.Params.Slug}}
 {{ end }}


### PR DESCRIPTION
Titles that have a dash do not create a slug correctly

### Description
When a slug was created for a title with a dash in it it would create a link with triple dashes.
Title example: This is a Title - Dashed
Before fix: this-is-a-title---dashed
After fix: this-is-a-title-dashed

### Issue
<!-- JIRA link -->

### Testing
Check the slug/link of a title with a dash

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
