### PR TITLE
PRSDM-2289: Fix tooltip link

### DIFF
--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -2,7 +2,6 @@
 {{ $ref := .Get 1}}
 {{ $page := "" }}
 
-
 {{ if $ref }}
     {{ $page = .Site.GetPage $ref }}
 {{ end }}
@@ -17,7 +16,13 @@
 {{ end }}
 
 {{ if $page }}
-    <a class="tooltips-term" href="{{ $page.Permalink }}" >
+    {{ $tooltipWord := print (path.Base $page.Permalink) }}
+    {{ $old := printf "%s/" $tooltipWord }}
+    {{ $new := printf "#%s" $tooltipWord }}
+    <!-- Insert a '#' symbol before the glossary term so that it correctly navigates to link -->
+    {{ $tooltipLink := replace $page.Permalink $old $new}}
+
+    <a class="tooltips-term" href="{{ $tooltipLink }}" >
         {{ $title }}<span class="tooltips-text">{{ $page.Content | truncate 100 | plainify }}</span>
     </a>
 {{ else }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
The anchor link reference to the tooltip glossary item does not correctly navigate the glossary term. The url required a # symbol before the the glossary term.

### Jira Link
https://spandigital.atlassian.net/browse/PRSDM-2289

### Description
- Simply just removed the trailing forward slash from the url
- Inserted a hash (#) symbol before the glossary term in url

Example:
Faulty url: http://localhost:1313/glossary/discretize/
Fixed url: http://localhost:1313/glossary/#discretize

### Issue
<!-- JIRA link -->

