### PR TITLE
Tooltip Fixes

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,2 +1,3 @@
 {{ define "content" }}
+{{ partial "article" . }}
 {{ end }}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -16,8 +16,15 @@
     {{ end }}
 {{ end }}
 
+{{ $slug := $page.Params.Slug }}
+{{ $isChild := not $page.Data.Pages}}
+{{ $articleLink := $page.Permalink }}
+{{if $isChild }}
+    {{ $articleLink = (printf "%v#%v" $page.Parent.Permalink $slug ) }}
+{{end}}
+
 {{ if $page }}
-    <a class="tooltips-term" href="{{ $page.Permalink }}" >
+    <a class="tooltips-term" href="{{ $articleLink }}" >
         {{ $title }}<span class="tooltips-text">{{ $page.Content | truncate 100 | plainify }}</span>
     </a>
 {{ else }}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -16,7 +16,13 @@
     {{ end }}
 {{ end }}
 
-{{ $slug := $page.Params.Slug }}
+{{/* Use title if no slug */}}
+{{ $slug := humanize .Params.Title }} {{/* Handles any dashes in the title */}}
+{{ $slug = anchorize $slug }}
+{{ if .Params.Slug }}
+    {{ $slug = .Params.Slug}}
+{{ end }}
+
 {{ $isChild := not $page.Data.Pages}}
 {{ $articleLink := $page.Permalink }}
 {{if $isChild }}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -17,10 +17,10 @@
 {{ end }}
 
 {{/* Use title if no slug */}}
-{{ $slug := humanize .Params.Title }} {{/* Handles any dashes in the title */}}
+{{ $slug := humanize $page.Params.Title }} {{/* Handles any dashes in the title */}}
 {{ $slug = anchorize $slug }}
-{{ if .Params.Slug }}
-    {{ $slug = .Params.Slug}}
+{{ if $page.Params.Slug }}
+    {{ $slug = $page.Params.Slug}}
 {{ end }}
 
 {{ $isChild := not $page.Data.Pages}}


### PR DESCRIPTION

### Description
- Changed the tooltip URL to be the same as the article URL i.e `parentpermalink/#slug`.
- Fixed the layout for single-page articles. 

### Issue
[PRS-2289](https://spandigital.atlassian.net/browse/PRSDM-2289?atlOrigin=eyJpIjoiOWY2NDEwOTg0ZTc4NDMzYWE4M2I5NDI1ODlkODJlYjciLCJwIjoiaiJ9)

### Testing
- Make sure tooltip links work
- Make sure article references work for example
```
[Click me]({{< ref "/introduction/history.md" >}})
```
or
```
[Click me]({{< ref "/introduction/#history" >}})
```
