### PR TITLE
Code syntax font size

### DIFF
--- a/assets/_sass/_syntax.scss
+++ b/assets/_sass/_syntax.scss
@@ -1,9 +1,3 @@
-code {
-  span {
-    font-size: 16px;
-  }
-}
-
 //Code block captions
 .highlighter-rouge + p > em {
   display: block;


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Removed the font size override for code blocks. See related [PR](https://github.com/SPANDigital/presidium-theme-apple/pull/20)

### Issue
[PRS-2337](https://spandigital.atlassian.net/browse/PRSDM-2337)
