### PR TITLE
fix/PRSDM-2386-urlize

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,15 +1,13 @@
 {{ $roles := .Params.roles | default "All Roles" }}
 
 {{/* Use title if no slug */}}
-{{ $slug := humanize .Params.Title }} {{/* Handles any dashes in the title */}}
-{{ $slug = anchorize $slug }}
+{{ $slug := urlize .Params.Title }}
 {{ if .Params.Slug }}
     {{ $slug = .Params.Slug}}
 {{ end }}
 
 {{/* Parent slug */}}
-{{ $parentSlug := ((humanize .Parent.Params.Title) | default "root") }}
-{{ $parentSlug = anchorize $parentSlug }}
+{{ $parentSlug := ((urlize .Parent.Params.Title) | default "root") }}
 {{ if .Parent.Params.Slug }}
     {{ $parentSlug = .Parent.Params.Slug}}
 {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -31,15 +31,13 @@
 {{ $isChild := not $isParent }}
 
 {{/* Use title if no slug */}}
-{{ $slug := humanize .NavPage.Params.Title }} {{/* Handles any dashes in the title */}}
-{{ $slug = anchorize $slug }}
+{{ $slug := urlize .NavPage.Params.Title }}
 {{ if .NavPage.Params.Slug }}
     {{ $slug = .NavPage.Params.Slug}}
 {{ end }}
 
 {{/* Parent slug */}}
-{{ $parentSlug := ((humanize .NavPage.Parent.Params.Title) | default "root") }}
-{{ $parentSlug = anchorize $parentSlug }}
+{{ $parentSlug := ((urlize .NavPage.Parent.Params.Title) | default "root") }}
 {{ if .NavPage.Parent.Params.Slug }}
     {{ $parentSlug = .NavPage.Parent.Params.Slug}}
 {{ end }}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -51,7 +51,7 @@
                         {{ if $menu.Params.externalUrl}}
                         {{ partial "nav-item-external" $menu }}
                     {{ else }}
-                        {{ $identifier := anchorize $menu.Identifier }}
+                        {{ $identifier := urlize $menu.Identifier }}
                         {{ with $.Site.GetPage $identifier }}
                             {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed  "RootUrl" $rootUrl "Show" false) }}
                         {{ end }}

--- a/layouts/partials/searchmap-item.html
+++ b/layouts/partials/searchmap-item.html
@@ -11,8 +11,7 @@
 {{ end }}
 
 {{ with .Page}}
-    {{ $slug := humanize .Params.Title }}
-    {{ $slug = anchorize $slug }}
+    {{ $slug := urlize .Params.Title }}
     {{ if .Params.Slug }}
         {{ $slug = .Params.Slug}}
     {{ end }}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -17,8 +17,7 @@
 {{ end }}
 
 {{/* Use title if no slug */}}
-{{ $slug := humanize $page.Params.Title }} {{/* Handles any dashes in the title */}}
-{{ $slug = anchorize $slug }}
+{{ $slug := urlize $page.Params.Title }}
 {{ if $page.Params.Slug }}
     {{ $slug = $page.Params.Slug}}
 {{ end }}


### PR DESCRIPTION
Changed the way slugs are generated

### Description
There were issues with the way the current way of generating slugs vs Jekyll. This new way of doing it brings it more in line with the old Jekyll version leaving less issues in older docs

### Issue
[JIRA](https://spandigital.atlassian.net/jira/software/projects/PRSDM/boards/100?assignee=61c4ebbc90cfd200716d410f&selectedIssue=PRSDM-2386)

### Testing
Go through the menu links and the associated anchor tags and make sure they are more like the title. Specific emphasis on periods, dashes, capital letters in the middle of words and other special characters (e.g &)

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
