### PR TITLE
fix/PRSDM-double-title

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,8 +5,6 @@
     {{ $siteScopes := .Site.Params.scopes }}
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
     {{ $pages := .Data.Pages }}
-    
-    {{ $index := 0 }}
   
     {{ range .Data.Pages.ByWeight }}
 
@@ -20,11 +18,8 @@
         {{ end }}
 
         {{ if $isRendering }}
-            {{ .Scratch.Set "index" $index }}
             {{ partial "article" . }}
         {{ end }}
-
-        {{ $index = add $index 1 }}
 
     {{ end }}
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -22,13 +22,12 @@
 {{ $pageSlug := (printf "%v-%v" ($parentSlug) $slug )}}
 {{ $nestedArticles := .Site.Params.includeNestedArticles | default true }}
 
-{{ $index := .Scratch.Get "index" }}
 
 <div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $pageSlug }}">
     {{ if or (ne (len .Content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $dataId }}"></span>
-        {{ if and (eq .Parent.Title .Title) (eq $index 0) }}
+        {{ if (eq .Parent.Title .Title) }}
             {{/*  No title - For when the main title is the same as the first article  */}}
         {{ else }}
             <div class="article-title" >


### PR DESCRIPTION
Child titles that match their parent titles should be hidden so only one title displays

### Description
Child titles were still showing under certain circumstances like being on a higher level article and in some cases refreshing multiple times would yield different results.

### Testing
Have _index.md `title` be the same as an article `title`

### Screenshots
Broken:
![Screenshot 2022-07-06 at 21 21 00](https://user-images.githubusercontent.com/12759737/177626709-684e2808-203d-4b2b-952a-3ed247a5b841.png)

Fixed:
![Screenshot 2022-07-06 at 21 21 29](https://user-images.githubusercontent.com/12759737/177626722-b733e67f-cbae-4c9a-8ca8-2021af0de418.png)

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
