### PR TITLE
Removed `nowrap` for table headers

### DIFF
--- a/assets/_sass/bootstrap/bootstrap/_tables.scss
+++ b/assets/_sass/bootstrap/bootstrap/_tables.scss
@@ -44,7 +44,6 @@ th {
   }
   // Bottom align for column headings
   > thead > tr > th {
-    vertical-align: bottom;
     border-bottom: 2px solid $table-border-color;
   }
   // Remove top border from thead by default
@@ -195,7 +194,7 @@ table {
         > tr {
           > th,
           > td {
-            white-space: nowrap;
+            white-space: normal;
           }
         }
       }


### PR DESCRIPTION
Made table headers wrap correctly instead of overflowing

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2557


### Screenshots
<!-- If relevant -->
<img width="608" alt="Screenshot 2022-07-26 at 09 24 31" src="https://user-images.githubusercontent.com/35559164/180948142-260aa2af-715f-4105-bef2-9d5096fa15ce.png">


### Checklist before merging

* [x] Did you test your changes locally?
