### PR TITLE
Set max width to 650px.

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -67,6 +67,10 @@
 
     .wysiwyg {
 
+      .codex-editor {
+        max-width: 650px;
+      }
+
       .editor-button {
         transition: background-color 0.01s;
         border-radius: 4px;


### PR DESCRIPTION
Created a max width limit for the editor.

### Description
Stipulating a max width stops the EditorJS elements from being misplaced when adjusting the window size.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2620

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
