### PR TITLE
Moved block tool to the left side of the editor

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -71,6 +71,19 @@
         max-width: 650px;
       }
 
+      .ce-popover {
+        left: -54px;
+      }
+
+      .codex-editor__redactor {
+        margin-right: 0px;
+      }
+
+      .ce-toolbar__actions {
+        right: 100%;
+        top: -2px;
+      }
+
       .editor-button {
         transition: background-color 0.01s;
         border-radius: 4px;


### PR DESCRIPTION
Moved the block tool to the left side of the editor to be more in line with designs.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2726

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
