### PR TITLE
Fix/prsdm 2758 filename weights

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
     {{ $pages := .Data.Pages }}
   
-    {{ range .Data.Pages.ByWeight }}
+    {{ range sort .Data.Pages "File.Path" }}
 
         {{ $isRendering := true }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,21 +5,47 @@
     {{ $siteScopes := .Site.Params.scopes }}
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
     {{ $pages := .Data.Pages }}
-  
-    {{ range sort .Data.Pages "File.Path" }}
 
-        {{ $isRendering := true }}
+    {{/* Sort by filename unless there is a missing digit prefix */}}
+    {{ $sortByFilename := true}}
+    {{ range $name := .Data.Pages }}
+        {{/* Find digits with a dash at the start of a filename */}}
+        {{ if eq nil (findRE `^\d+-` $name.File.ContentBaseName 1) }}
+            {{/*  Default back to weight if a file is missing the prefix */}}
+            {{ $sortByFilename = false }}  
+        {{ end }}
+    {{ end }}
+    {{ if $sortByFilename }}
+        {{/* Sort by file prefix */}}
+        {{ range sort .Data.Pages "File.Path" }}
+            {{ $isRendering := true }}
 
-        {{ if $siteScopesEnabled }}
-            {{ if isset .Params "scope" }}
-                {{ $pageScopes := .Params.scope }}
-                {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}    
+            {{ if $siteScopesEnabled }}
+                {{ if isset .Params "scope" }}
+                    {{ $pageScopes := .Params.scope }}
+                    {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}    
+                {{ end }}
+            {{ end }}
+
+            {{ if $isRendering }}
+                {{ partial "article" . }}
             {{ end }}
         {{ end }}
+    {{ else }}
+        {{/* Sort by weight otherwise the hugo default */}}
+        {{ range .Data.Pages.ByWeight }}
+            {{ $isRendering := true }}
 
-        {{ if $isRendering }}
-            {{ partial "article" . }}
+            {{ if $siteScopesEnabled }}
+                {{ if isset .Params "scope" }}
+                    {{ $pageScopes := .Params.scope }}
+                    {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}    
+                {{ end }}
+            {{ end }}
+
+            {{ if $isRendering }}
+                {{ partial "article" . }}
+            {{ end }}
         {{ end }}
-
     {{ end }}
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -50,8 +50,25 @@
         <article>{{ .Content }}</article>
 
         {{ if $nestedArticles }}
-            {{ range sort .Data.Pages "File.Path" }}
-                {{ partial "article" . }}
+            {{/* Sort by filename unless there is a missing digit prefix */}}
+            {{ $sortByFilename := true}}
+            {{ range $name := .Data.Pages }}
+                {{/* Find digits with a dash at the start of a filename */}}
+                {{ if eq nil (findRE `^\d+-` $name.File.ContentBaseName 1) }}
+                    {{/*  Default back to weight if a file is missing the prefix */}}
+                    {{ $sortByFilename = false }}  
+                {{ end }}
+            {{ end }}
+            {{ if $sortByFilename }}
+                {{/* Sort by file prefix */}}
+                {{ range sort .Data.Pages "File.Path" }}
+                    {{ partial "article" . }}
+                {{ end }}
+            {{ else }}
+                {{/* Sort by weight otherwise the hugo default */}}
+                {{ range .Data.Pages.ByWeight }}
+                    {{ partial "article" . }}
+                {{ end }}
             {{ end }}
         {{ end }}
 

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -50,7 +50,7 @@
         <article>{{ .Content }}</article>
 
         {{ if $nestedArticles }}
-            {{ range .Data.Pages.ByWeight }}
+            {{ range sort .Data.Pages "File.Path" }}
                 {{ partial "article" . }}
             {{ end }}
         {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -81,8 +81,25 @@
 
     {{ if $isParent }}
         <ul>
-        {{ range $index, $subMenu := (sort (after $offset .NavPage.Data.Pages) "File.Path") }}
-            {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
+        {{/* Sort by filename unless there is a missing digit prefix */}}
+        {{ $sortByFilename := true}}
+        {{ range $name := .NavPage.Data.Pages }}
+            {{/* Find digits with a dash at the start of a filename */}}
+            {{ if eq nil (findRE `^\d+-` $name.File.ContentBaseName 1) }}
+                {{/*  Default back to weight if a file is missing the prefix */}}
+                {{ $sortByFilename = false }}  
+            {{ end }}
+        {{ end }}
+        {{ if $sortByFilename }}
+            {{/* Sort by file prefix */}}
+            {{ range $index, $subMenu := (sort (after $offset .NavPage.Data.Pages) "File.Path") }}
+                {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
+            {{ end }}
+        {{ else }}
+            {{/* Sort by weight otherwise the hugo default */}}
+            {{ range $index, $subMenu := .NavPage.Data.Pages.ByWeight }}
+                {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
+            {{ end }}
         {{ end }}
         </ul>
     {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -81,7 +81,7 @@
 
     {{ if $isParent }}
         <ul>
-        {{ range $index, $subMenu := after $offset .NavPage.Data.Pages }}
+        {{ range $index, $subMenu := (sort (after $offset .NavPage.Data.Pages) "File.Path") }}
             {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
         {{ end }}
         </ul>


### PR DESCRIPTION
Allows the user to use a digit prefix (e.g. 01-) in the filename to order content

### Description
By prefixing files and directories with `01-`, `02-` etc. the theme can now order by this prefix instead of weight. This fix maintains the ability to use weight and the Hugo default sorting. The file prefix is required on all files in a directory otherwise it will fallback to weight.

**NOTE**: using the file prefix will mean the url will have that prefix. Hugo only allows very basic permalink changes. The only way around this currently is the use `url:` in the front matter of the _index.md files.

### Issue
[PRSDM-2758](https://spandigital.atlassian.net/browse/PRSDM-2758)

### Testing
Rename all files and directories in a directory to have a prefix of `01-`, `02-`, `03-` etc. and see if they order correctly in the site. Leaving the prefix will order by weight and if no weight by the Hugo fallback defaults found [here](https://gohugo.io/templates/lists/#order-content)

### Screenshots
Example Folder Structure where anything in Overview uses the file prefix and everything in Key Concepts uses weight:
![Example Folder Structure](https://user-images.githubusercontent.com/12759737/194234044-76e1bd02-bd6a-46ab-8ee0-a0c31ba19b7c.png)

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change? - will update if everything is okay
* [x] Did you test your changes locally?
