### PR TITLE
fix/PRSDM-2762-page-jumping

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -69,8 +69,19 @@
                 event.preventDefault();
                 $('.navbar-items').toggle('expanded');
             });
-
+            
+            
         });
+    </script>
+    <script>
+      // Unhide all the iframes in the documents
+      // iframes are hidden by default when using embed shortcode in order to stop page jumping
+      window.onload = function() {
+        var collection = document.getElementsByTagName("iframe");
+        for (var i = 0; i < collection.length; i++) {     
+            collection[i].style.display = 'block';
+        }
+      }
     </script>
 
     <!-- Components -->

--- a/layouts/shortcodes/embed.html
+++ b/layouts/shortcodes/embed.html
@@ -1,0 +1,5 @@
+{{ $src := .Get "src" }}
+{{ $width := .Get "width" | default "100%" }}
+{{ $height := .Get "height" | default "800px" }}
+
+<iframe src="{{$src}}" width="{{$width}}" height="{{$height}}" style="display:none"></iframe>


### PR DESCRIPTION
This is stop some iframes from navigating to another part of the page when they load.

### Description
Added a shortcode called embed that uses iframes and hides them by default with some JS to unhide them after the window has loaded. The shortcode is used: `{{< embed src="">}}` with optional width and height fields

### Issue
[PRSDM-2762](https://spandigital.atlassian.net/browse/PRSDM-2762)

### Testing
Use the SPAN handbook on branch `SPAN-Approach-2.0` in `content` -> `span-approach` there are many iframes. The ones causing issue for me are the following files:  `artifact-template`, `estimation-spreadsheet` and `intent-and-objectives-document` all are in `05-project-artifacts`

### Screenshots
N/A

### Checklist before merging

* [x] Is this code covered by tests?
* [x] Is the documentation updated for this change? - will update on approval
* [x] Did you test your changes locally?
