### PR TITLE
Feat/prsdm 2751 wysiwyg save icon

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -110,6 +110,26 @@
         border-style: none;
         border-radius: 3px;
         color: white;
+        min-width: 46px;
+        max-height: 27px;
+
+        svg {
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            animation: rotation 1s infinite linear;
+        }
+
+        @keyframes rotation {
+            from {
+                transform: rotate(0deg);
+            }
+            to {
+                transform: rotate(359deg);
+            }
+        }
+
         &:hover {
           background-color: darken($brand-primary, 10%);
         }

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -284,7 +284,7 @@
         position: absolute;
         padding: 0px 20px;
         top: 12px;
-        left: -70px;
+        left: -48px;
       }
 
       .article-title {


### PR DESCRIPTION
Added styles for a spinner within the save button on the WYSIWYG editor.
Moved the article options slightly to accommodate for the removal of the delete button. Will be reverted later.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2751

### Screenshots
<img width="82" alt="Screenshot 2022-10-17 at 15 57 33" src="https://user-images.githubusercontent.com/35559164/196198359-d9002854-27b5-4156-8212-300fb1a31d8b.png">

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
