### PR TITLE
Moved the popover back to its original position to avoid it being obs…

### DIFF
--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -2,10 +2,6 @@
     max-width: 650px;
 }
 
-.ce-popover {
-    left: -54px;
-}
-
 .codex-editor__redactor {
     margin-right: 0px;
 }


### PR DESCRIPTION
The EditorJS popover was being obscured by the navbar. This PR moves it to the right.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2906

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
