### PR TITLE
Bugfix/prsdm 2961 quote before style

### DIFF
--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -10,6 +10,10 @@
     display: none;
 }
 
+.cdx-quote [contentEditable=true][data-placeholder]::before { 
+    display: none;
+}
+
 .ce-toolbar__actions {
     right: 100%;
     top: -2px;

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -6,10 +6,6 @@
     margin-right: 0px;
 }
 
-.cdx-quote__caption { 
-    display: none;
-}
-
 .cdx-quote [contentEditable=true][data-placeholder]::before { 
     display: none;
 }


### PR DESCRIPTION
Fixed a bug where a random new line would appear at the beginning of a quote block.

Part of https://github.com/SPANDigital/presidium-js-enterprise/pull/231

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2961

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
