### PR TITLE
Fix/prsdm 2963 pdf styling

### DIFF
--- a/assets/_sass/_pdf.scss
+++ b/assets/_sass/_pdf.scss
@@ -1,0 +1,1 @@
+// Placeholder for PDF theme styles when needed - so it doesn't override brand theme in _custom.scss

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -17,3 +17,4 @@
 @import '_sass/default-fonts';
 @import '_sass/fonts';
 @import '_sass/custom';
+@import '_sass/_pdf'

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -17,4 +17,4 @@
 @import '_sass/default-fonts';
 @import '_sass/fonts';
 @import '_sass/custom';
-@import '_sass/pdf'
+@import '_sass/pdf';

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -17,4 +17,4 @@
 @import '_sass/default-fonts';
 @import '_sass/fonts';
 @import '_sass/custom';
-@import '_sass/_pdf'
+@import '_sass/pdf'


### PR DESCRIPTION
Added placeholder file for pdf themes

### Description
Needed an additional placeholder file for the pdf themes to stop issues with Apple theme using the _custom.scss file

### Issue
[JIRA link](https://spandigital.atlassian.net/browse/PRSDM-2963)

### Testing
Use all three themes together and load the site. Theme order PDF - Apple - Website


### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [x] Did you test your changes locally?
