### PR TITLE
fix/PRSDM-2973-double-heading

### DIFF
--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -93,7 +93,7 @@
             {{ end }}
         {{ else }}
             {{/* Sort by weight otherwise the hugo default */}}
-            {{ range $index, $subMenu := .NavPage.Data.Pages.ByWeight }}
+            {{ range $index, $subMenu := after $offset .NavPage.Data.Pages.ByWeight }}
                 {{ partial "nav-item" (dict "CurrentPage" $currentPage "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "Show" $openMenu) }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
Missing some code to hide double headings because of a recent change

### Description
Just added in the extra code to hide headings that match their parents. This been in for a while but an edge case appear due to recent changes for the sortByFilePath

### Issue
[JIRA link](https://spandigital.atlassian.net/browse/PRSDM-2973)

### Testing
Have a section heading be the same as an article heading. The article header should be hidden

### Checklist before merging

* [ ] Is this code covered by tests?
* [x] Is the documentation updated for this change?
* [x] Did you test your changes locally?
