### PR TITLE
Inject article path into attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 ## 2022-11-15
 ### Updates
 - Improve load times by preloading WYSIWYG icons @SamShiels
+- Inject the article path into an HTML attribute for use in the React app @SamShiels https://spandigital.atlassian.net/browse/PRSDM-2985

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -13,6 +13,8 @@
     {{ $parentSlug = .Parent.Params.Slug}}
 {{ end }}
 
+{{ $articleLink := (printf "%v#%v" .Parent.Page.Permalink $slug ) }}
+
 {{ $type := "parent" }}
 {{if not .Data.Pages }}
     {{ $type = "child" }}
@@ -25,7 +27,7 @@
     {{ $content = len .Content }}
 {{ end }}
 
-<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $pageSlug }}">
+<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $pageSlug }}" data-link="{{ $articleLink }}">
     {{ if or (ne ($content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $dataId }}"></span>


### PR DESCRIPTION
Inject the article path into an HTML attribute for use in the React app.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2985

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
* [ ] Did you test your changes locally?
