### PR TITLE
Move z-index to dropdown parent

### DIFF
--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -169,13 +169,13 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         
         .dropdown {
           display: block;
+          z-index: $zindex-navbar;
 
           .dropdown__control {
             background-color: transparent;
           }
           .dropdown__menu {
             width: 200px;
-            z-index: 100;
           }
           .dropdown__option {
             color: white;


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
<!-- A longer description of the change -->
Moves existing z-index setting to `.dropdown`, raising the entire dropdown above the scrollbar.
### Issue
<!-- JIRA link -->
https://spandigital.atlassian.net/browse/PRSDM-2952
### Testing
<!-- Provide QA steps -->
1. Visit site with entries
2. Expand entries until they overflow the area
3. Click on the dropdown arrow
### Screenshots
<!-- If relevant -->
![image](https://user-images.githubusercontent.com/10201206/203301394-5c19eb5d-94c9-47d8-a7f5-950abd6c3c8e.png)


### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] ~Is the documentation updated for this change? (If Required)~
