### PR TITLE
Align editor-popup-panel text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 ## 2022-11-23
 ### Updates
 - Ensure entire site's contents wrap correctly
+
+## 2022-11-30
+### Bug Fixes
+- Center align editor-popup-panel text @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-2971

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -18,7 +18,7 @@ body::after{
     margin-right: 0px;
 }
 
-.cdx-quote [contentEditable=true][data-placeholder]::before { 
+.cdx-quote [contentEditable=true][data-placeholder]::before {
     display: none;
 }
 
@@ -79,6 +79,10 @@ body::after{
     font-weight: bold;
     text-align: center;
 
+    .popup-text {
+        height: 20px;
+        margin-bottom: 12px;
+    }
 }
 
 .editor-popup-panel-loading {

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -77,6 +77,7 @@ body::after{
     padding: 12px;
     line-height: 22px;
     font-weight: bold;
+    text-align: center;
 
 }
 

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -88,7 +88,7 @@ body::after{
 .editor-popup-panel-loading {
     @extend .editor-popup-panel;
     background-color: #777777;
-    grid-template-columns: auto 30px;
+    grid-template-columns: 40px auto 30px;
 }
 
 .editor-popup-panel-error {
@@ -138,14 +138,18 @@ body::after{
     }
 }
 
-.popup-alert {
-    background-image: url('assets/svg/icon-alert.png');
-    background-size: 20px 20px;
-    background-repeat: no-repeat;
+.popup-alert-spacer {
     top: 0;
     left: 0;
     width: 20px;
     height: 20px;
+}
+
+.popup-alert {
+    @extend .popup-alert-spacer;
+    background-image: url('assets/svg/icon-alert.png');
+    background-size: 20px 20px;
+    background-repeat: no-repeat;
 }
 
 .editor-options {

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -74,14 +74,13 @@ body::after{
 
     display: grid;
 
-    padding: 12px;
+    padding: 11px 12px 13px 12px;
     line-height: 22px;
     font-weight: bold;
     text-align: center;
 
     .popup-text {
         height: 20px;
-        margin-bottom: 12px;
     }
 }
 
@@ -104,7 +103,7 @@ body::after{
         transition: background-color 0.01s;
         border-radius: 4px;
         height: 20px;
-        line-height: 20px;
+        line-height: 0;
         border: none;
 
 


### PR DESCRIPTION
Align editor-popup-panel text

### Description
Align editor-popup-panel text

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2971

### Testing
Confirmed the text is now centred

### Screenshots
![Screenshot 2022-11-30 at 11 25 51](https://user-images.githubusercontent.com/59831464/204758030-f812b744-2c99-4d45-95c9-9b7b1b7c0eaa.png)
![Screenshot 2022-11-30 at 11 26 29](https://user-images.githubusercontent.com/59831464/204758163-0f9c6a34-e180-49ca-a72e-0e13e7a4d1b3.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
