### PR TITLE
Fix pdf dropdown click outside bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,8 @@
 ### Bug Fixes
 - Center align editor-popup-panel text @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-2971
 - Fixed the size of the editor modal <p> element @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3035
+
+## 2022-12-05
+### Updates
+- Changed styling of the navbar dropdown component to match the design prototype here: https://www.figma.com/proto/dLmmaBBBfImSB7AIQnucDL/Export-Project-PDF?page-id=0%3A1&node-id=401%3A20062&viewport=1063%2C459%2C0.25&scaling=min-zoom&starting-point-node-id=2%3A2
+- When the dropdown is expanded and the user clicks outside of the dropdown area it now collapses the dropdown menu.

--- a/assets/_sass/_default-variables.scss
+++ b/assets/_sass/_default-variables.scss
@@ -15,6 +15,8 @@ $color-yellow-green: #beb239;
 $color-green: #84a93f;
 $color-blue: #4586cd;
 $color-red: #e52213;
+$color-white: #ffffff;
+$color-black: #000;
 
 // Fonts
 $primary-font-family: 'Gotham', sans-serif !default;

--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -91,7 +91,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         background-color: #fff;
         border-radius: $border-radius-base;
         border: 1px solid $border;
-        -webkit-box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25); 
+        -webkit-box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25);
         box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25);
       }
     }
@@ -156,7 +156,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
           font-family: $primary-font-family;
           text-transform: none;
           text-align: center;
-  
+
           @media (max-width: $grid-float-breakpoint) {
             display: none; //hidden by default
             float: left;
@@ -166,33 +166,46 @@ $nav-item-border: darken($navbar-default-bg, 8%);
             @include navbar-vertical-align(14px);
           }
         }
-        
+
         .dropdown {
           display: block;
           z-index: $zindex-navbar;
 
           .dropdown__control {
             background-color: transparent;
+            margin: 0px 6px;
+            fill: $color-grey-2;
+            &:hover {
+              background-color: $color-grey-4;
+            }
           }
+
+          .dropdown__control--menu-is-open {
+            background-color: $color-blue;
+            fill: $color-white;
+            & > svg {
+              fill: $color-white;
+            }
+            &:hover {
+              background-color: $color-blue;
+              fill: $color-white;
+            }
+
+           }
           .dropdown__menu {
             width: 200px;
           }
           .dropdown__option {
-            color: white;
+            color: $color-black;
+            &:hover {
+              background-color: $color-grey-4;
+            }
           }
           .dropdown__option--is-focused {
-            background-color: $brand-primary;
-          }
-          .dropdown__option--is-selected  {
-            background-color: $brand-primary;
+            background-color: $color-white;
           }
           .dropdown__indicator--is-focused {
             color: white;
-            background-color: $brand-primary;
-          }
-          .dropdown__indicator--is-selected  {
-            color: $brand-primary;
-            background-color: $brand-primary;
           }
           .dropdown__indicator-separator  {
             display: none;
@@ -200,14 +213,10 @@ $nav-item-border: darken($navbar-default-bg, 8%);
           .dropdown__indicators  {
             max-height: 10px;
             margin: auto;
+            margin-top: -16px;
           }
-          .dropdown__control--is-focused .dropdown__dropdown-indicator > svg {
-            fill: $brand-primary;
-          }
-          .dropdown__control--is-selected .dropdown__dropdown-indicator > svg {
-            fill: $brand-primary;
-          }
-          .dropdown__value-container {
+
+          .dropdown__placeholder{
             display: none;
           }
         }
@@ -386,7 +395,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         > div > a {
           color: $brand-primary;
         }
-        
+
         &.child .add-icon,
           &.closed .add-icon {
           background-image: url('assets/svg/plus-white.svg');


### PR DESCRIPTION
Summary of fixes:
* Changed styling of dropdown component to match the design 
* When the dropdown is expanded and the user clicks outside of the dropdown area it now collapses the dropdown menu.
* Replaced the Down chevron icon button with the meatball menu icon


### Description

View the Jira ticket below for description of bug issue.

View Design Prototype here:  https://www.figma.com/proto/dLmmaBBBfImSB7AIQnucDL/Export-Project-PDF?page-id=0%3A1&node-id=401%3A20062&viewport=1063%2C459%2C0.25&scaling=min-zoom&starting-point-node-id=2%3A2

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2886

### Screenshots
<img width="965" alt="Screenshot 2022-12-05 at 1 57 40 PM" src="https://user-images.githubusercontent.com/41419154/205632091-5fae81aa-7ed8-441c-9b3f-9a552b71b9a1.png">
<img width="1024" alt="Screenshot 2022-12-05 at 1 58 04 PM" src="https://user-images.githubusercontent.com/41419154/205632107-6911004f-eee9-4782-8ff4-478d6cd25ff9.png">


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
