### PR TITLE
PRSDM-2882-inline-img-attr-spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@
 ### Updates
 ### Bug Fixes
 
+## 2022-12-05
+### Updates
+- Updated img shortcode to allow spaces in the attributes fields
+
+## 2022-11-30
+### Bug Fixes
+- Center align editor-popup-panel text @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-2971
+- Fixed the size of the editor modal <p> element @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3035
+
+## 2022-11-23
+### Updates
+- Ensure entire site's contents wrap correctly
+
 ## 2022-11-15
 ### Updates
 - Improve load times by preloading WYSIWYG icons @SamShiels
 - Inject the article path into an HTML attribute for use in the React app @SamShiels https://spandigital.atlassian.net/browse/PRSDM-2985
 - Preload article create and delete icons @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3005
-
-## 2022-11-23
-### Updates
-- Ensure entire site's contents wrap correctly
-## 2022-11-30
-### Bug Fixes
-- Center align editor-popup-panel text @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-2971
-- Fixed the size of the editor modal <p> element @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3035

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,6 @@
 {{ define "content" }}
 
     {{.Content}}
-    {{ partial "article" . }}
 
     {{ $siteScopes := .Site.Params.scopes }}
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,7 @@
 {{ define "content" }}
 
     {{.Content}}
+    {{ partial "article" . }}
 
     {{ $siteScopes := .Site.Params.scopes }}
     {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -14,13 +14,13 @@
 {{ $attrs := ""}}
 {{ range $key, $value :=  .Params}}
     {{ if not (in $ignore $key) }}
-        {{ $attrs = (printf "%s=%s %s" $key $value $attrs)}}
+        {{ $attrs = (printf "%s=\"%s\" %s" $key $value $attrs) | safeHTMLAttr}}
     {{ end }}
 {{ end }}
 {{/* IMPORTANT! Keep indents minimal, there is an issue with indents translating into some content being put into <pre><code> blocks (when combined with other shortcodes) */}}
 <figure {{ with .Get "class" }}class="{{.}}"{{ end }}>
 {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-<img src="{{ $src }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs | safeHTMLAttr}} />
+<img src="{{ $src }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs}} />
 {{ if .Get "link"}}</a>{{ end }}
 {{ if isset .Params "caption" }}
 <em>


### PR DESCRIPTION
Updated img shortcode to allow spaces

### Description
You could not have spaces in the attributes field like styles, it would break and add each space as a new element

### Issue
[JIRA link](https://spandigital.atlassian.net/browse/PRSDM-2882)

### Testing
Use an image shortcode `{{< img src="" alt="" caption="" style="">}}` and add multiple styles with spaces after the colon or semi-colon. It should still work as expected

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
