### PR TITLE
Display entire tooltip content. Enable scrolling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,7 @@
 ## 2022-12-08
 ### Bug Fixes
 - Fixed an issue where editor modal overlays would not be on top. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3155
+
+## 2022-12-19
+### Features
+- Display all content within a tooltip. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3158

--- a/assets/_sass/_tooltips.scss
+++ b/assets/_sass/_tooltips.scss
@@ -62,6 +62,7 @@ $tooltip-triangle-top: -20%;
     -o-transition: $tooltip-animation;
     transition: $tooltip-animation;
     overflow: auto;
+    max-height: 76px;
   }
 
   &:hover .tooltips-text {

--- a/assets/_sass/_tooltips.scss
+++ b/assets/_sass/_tooltips.scss
@@ -61,6 +61,7 @@ $tooltip-triangle-top: -20%;
     -ms-transition: $tooltip-animation;
     -o-transition: $tooltip-animation;
     transition: $tooltip-animation;
+    overflow: auto;
   }
 
   &:hover .tooltips-text {

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -35,7 +35,7 @@
 
     {{ if $page }}
         <a class="tooltips-term" href="{{ $articleLink }}" >
-            {{ $title }}<span class="tooltips-text">{{ $page.Content | truncate 100 | plainify }}</span>
+            {{ $title }}<span class="tooltips-text">{{ $page.Content | plainify }}</span>
         </a>
     {{ else }}
         {{ if $ref }}


### PR DESCRIPTION
Display all content within a tooltip. Scroll when the content exceeds the bounds.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3158

### Testing
1. Checkout "SPAN-Approach-2.0" on SPAN Handbook.
2. Go to docs/span-handbook/#contribution
3. Hover over a tooltip.
4. Scroll through the content.

### Screenshots
![image](https://user-images.githubusercontent.com/35559164/208371365-30a851bf-4309-4d5f-a820-6a313798eac9.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [ x Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
