### PR TITLE
Override EditorJS style to ensure the tune menu stays where it's supp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,7 @@
 ## 2022-12-19
 ### Features
 - Display all content within a tooltip. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3158
+
+## 2023-01-09
+### Bugfixes
+- Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px.

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -14,6 +14,12 @@ body::after{
     max-width: 650px;
 }
 
+@media (min-width: 651px) {
+    .codex-editor--narrow .ce-toolbar__actions {
+        right: 100%;
+    }
+}
+
 .codex-editor__redactor {
     margin-right: 0px;
 }


### PR DESCRIPTION
Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3163

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
