### PR TITLE
Added media query for pdf button when the page is narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,4 +43,8 @@
 
 ## 2023-01-09
 ### Bugfixes
-- Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px.
+- Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px. @SamShiels
+
+## 2023-01-11
+### Bugfixes
+- Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3223

--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -145,6 +145,9 @@ $nav-item-border: darken($navbar-default-bg, 8%);
 
       .brand-name-grid {
         display: grid;
+        @media (max-width: $grid-float-breakpoint) {
+          grid-template-columns: 0px auto 50px;
+        }
         grid-template-columns: 50px auto 50px;
 
         .brand-name {


### PR DESCRIPTION
Position the pdf button correctly when the page width is small.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3223

### Screenshots
<img width="102" alt="image" src="https://user-images.githubusercontent.com/35559164/211742692-d01b8592-ebc1-416d-aa37-82c17f882b27.png">

### Checklist before merging

* [x] Did you test your changes locally? (Chrome, Firefox and Safari)
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
