### PR TITLE
Styles for article options when the viewport is narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,7 @@
 ## 2023-01-11
 ### Bugfixes
 - Fixed a bug where the editor tune menu would swap sides if the page width goes below 651px. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3223
+
+## 2023-01-12
+### Bugfixes
+- Placed the article option buttons to the right of the header when the viewport is narrowed. Limit the title width to account for the permalink and article options. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3224

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -80,12 +80,22 @@
         position: absolute;
         padding: 0px 20px;
         top: 12px;
-        left: -48px;
+        left: -70px;
+        height: 100%;
+        
+        @media (max-width: $grid-float-breakpoint) {
+          left: unset;
+          right: 0px;
+        }
       }
 
       .article-title {
         display: flex;
         align-items: center;
+
+        @media (max-width: $grid-float-breakpoint) {
+          max-width: calc(100vw - 120px);
+        }
 
         @include headings {
           &:hover {


### PR DESCRIPTION
Brought styles over from the React app. Placed the article option buttons to the right of the header when the viewport is narrowed. Limit the title width to account for the permalink and article options when the screen is narrow.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3224

### Testing
1. Checkout the branch of https://github.com/SPANDigital/presidium-js-enterprise/pull/262
2. Adjust the width of the page so that is is below 768px.
3. Observe the positioning of the article options.

### Screenshots
<img width="645" alt="Screenshot 2023-01-12 at 12 13 55" src="https://user-images.githubusercontent.com/35559164/212043358-fa98a44a-c47c-408f-a869-8c4e75c61be4.png">

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
