### PR TITLE
Prsdm 3226 fix pdf shortcode img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## 2023-01-12
 ### Bug Fixes
-- Fix img shortcode not rendering in the PDF document @Zalaras
+- Fix img shortcode not rendering in the PDF document @Zalaras https://spandigital.atlassian.net/browse/PRSDM-3226
 
 ## 2022-12-08
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Updates
 ### Bug Fixes
 
+## 2023-01-12
+### Bug Fixes
+- Fix img shortcode not rendering in the PDF document @Zalaras
+
 ## 2022-12-08
 ### Updates
 - Ensure popup panel symmetry

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -20,7 +20,7 @@
 {{/* IMPORTANT! Keep indents minimal, there is an issue with indents translating into some content being put into <pre><code> blocks (when combined with other shortcodes) */}}
 <figure {{ with .Get "class" }}class="{{.}}"{{ end }}>
 {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-<img src="{{ $src }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs}} />
+<img src="{{ $src | safeURL}}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs}} />
 {{ if .Get "link"}}</a>{{ end }}
 {{ if isset .Params "caption" }}
 <em>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,13 +1,13 @@
 {{ $src := .Get "src" }}
 {{ $url := urls.Parse $src }}
 {{ $src = strings.TrimPrefix "/" $src }}
-{{ $rootUrl := strings.TrimSuffix "/" ( relURL "/")}}
+
 {{ if .Page.Parent.Resources.GetMatch $src }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.RelPermalink | default "") $src }}
 {{ else if .Page.Parent.Parent.Resources.GetMatch $src }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.Parent.RelPermalink | default "") $src }}
 {{ else if not $url.Scheme  }}
-    {{ $src = printf "%s/%s" $rootUrl $src }}  
+    {{ $src = printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) $src }}  
 {{ end }}
 
 {{ $ignore := (slice "attrlink" "attr" "link" "alt" "caption" "title" "src")}}
@@ -20,7 +20,7 @@
 {{/* IMPORTANT! Keep indents minimal, there is an issue with indents translating into some content being put into <pre><code> blocks (when combined with other shortcodes) */}}
 <figure {{ with .Get "class" }}class="{{.}}"{{ end }}>
 {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-<img src="{{ $src | safeURL}}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs}} />
+<img src="{{ $src | safeURL }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} {{$attrs}} />
 {{ if .Get "link"}}</a>{{ end }}
 {{ if isset .Params "caption" }}
 <em>


### PR DESCRIPTION
Images using the shortcode no longer render in the PDF document

### Description
Images in the shortcode need the baseurl to render in the PDF

### Issue
[PRSDM-3226](https://spandigital.atlassian.net/browse/PRSDM-3226)

### Testing
Create a PDF from a doc site that has an images using the `img` shortcode

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
