### PR TITLE
Added permalink attribute to the article div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,7 @@
 ## 2023-01-12
 ### Bugfixes
 - Placed the article option buttons to the right of the header when the viewport is narrowed. Limit the title width to account for the permalink and article options. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3224
+
+## 2023-01-20
+### Bugfixes
+- Added the permalink to the article div so that we can edit landing pages. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3285

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -26,7 +26,7 @@
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}
 {{ $uid := .File.UniqueID }}
 
-<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}">
+<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.Permalink}}">
     {{ if or (ne ($content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -26,7 +26,7 @@
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}
 {{ $uid := .File.UniqueID }}
 
-<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.Permalink}}">
+<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}">
     {{ if or (ne ($content) 0) $nestedArticles }}
     <div class="presidium-article-wrapper">
         <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>


### PR DESCRIPTION
Added permalink attribute to the article div. This is so that we can edit landing pages. i.e. pages that have the same title as the section.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3285

### Screenshots
![Screenshot 2023-01-19 at 13 14 33](https://user-images.githubusercontent.com/35559164/213667388-907e9252-5816-48a3-a44e-04412ef98e74.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
