### PR TITLE
added site wide mermaid theme with Span colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Updates
 ### Bug Fixes
 
+## 2023-012-03
+### Updates
+- Added a site wide base theme to mermaid diagrams in the Span theme colours
+
 ## 2023-01-12
 ### Bug Fixes
 - Fix img shortcode not rendering in the PDF document @Zalaras https://spandigital.atlassian.net/browse/PRSDM-3226

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -82,7 +82,16 @@
         window.presidium.tooltips.load();
         window.presidium.modal.init();
 
-        mermaid.initialize({ startOnLoad: true });
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'base',
+            themeVariables: {
+                'primaryColor': '#E69224',
+                'primaryBorderColor': '#DE7f1D',
+                'secondaryColor': '#EAEAEA',
+                'lineColor': '#666',
+            },
+        });
     </script>
 
     {{ if $.Site.Params.enterprise_enabled }}


### PR DESCRIPTION
PRSDM-3388: added site wide theme for mermaid

### Description
<!-- A longer description of the change -->
John was looking at initialising a site wide theme for mermaid graphs using the Span theme colours. This PR adds the site wide theme to mermaid which will by default theme all graphs across presidium sites using this theme.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3388

### Screenshots
![image](https://user-images.githubusercontent.com/25523248/216629942-52805e0e-066b-417b-8a72-d4cd0146d17d.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
