### PR TITLE
Bugfix/prsdm 3445 mermaid text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,7 @@
 ## 2023-01-20
 ### Bugfixes
 - Added the permalink to the article div so that we can edit landing pages. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3285
+
+## 2023-02-09
+### Bugfixes
+- Override Mermaid JS CSS to allow for different edge and node text colours @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3445

--- a/assets/_sass/_mermaid.scss
+++ b/assets/_sass/_mermaid.scss
@@ -1,0 +1,13 @@
+// Mermaid JS does not seem to allow you to have different colours for the edge and node text.
+// In order to remedy this, we are directly overriding the CSS so we can make it look the way
+// we want.
+
+.edgeLabel {
+    // Make the color of the text within the links black
+    color: black !important;
+}
+
+.nodeLabel {
+    // Make the color of the text within the main nodes white
+    color: white !important;
+}

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -18,3 +18,4 @@
 @import '_sass/fonts';
 @import '_sass/custom';
 @import '_sass/pdf';
+@import '_sass/mermaid';

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -86,9 +86,9 @@
             startOnLoad: true,
             theme: 'base',
             themeVariables: {
-                'primaryColor': '#E69224',
-                'primaryBorderColor': '#DE7f1D',
-                'secondaryColor': '#EAEAEA',
+                'primaryColor': '#00827E',
+                'primaryBorderColor': '#2C6764',
+                'secondaryColor': '#FFFFFF',
                 'lineColor': '#666',
             },
         });


### PR DESCRIPTION
Mermaid JS does not seem to allow you to have different colours for the edge and node text.
In order to remedy this, we are directly overriding the CSS so we can make it look the way we want.
Yes, the `!important`'s are necessary.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3445

### Screenshots
![image](https://user-images.githubusercontent.com/35559164/217781259-37541ff5-9cd7-4343-bae5-bcebecd686f9.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
