### PR TITLE
Prsdm 3465 replace multiple dashes in slugs with one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,7 @@
 ## 2023-02-09
 ### Bugfixes
 - Override Mermaid JS CSS to allow for different edge and node text colours @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3445
+
+## 2023-02-15
+### Bugfixes
+- Replace multiple dashes in slugs with one. @LantareCode https://spandigital.atlassian.net/browse/PRSDM-3465

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -2,6 +2,7 @@
 {{/* Use title if no slug */}}
 {{ $slug := humanize .Params.Title }} {{/* Handles any dashes in the title */}}
 {{ $slug = anchorize $slug }}
+{{ $slug = replaceRE `(-{2,})` "-" $slug }} {{/* Replaces multiple dashes with one */}}
 {{ if .Params.Slug }}
     {{ $slug = .Params.Slug}}
 {{ end }}

--- a/layouts/partials/nav-item.html
+++ b/layouts/partials/nav-item.html
@@ -12,6 +12,7 @@
 {{/* Use title if no slug */}}
 {{ $slug := humanize .NavPage.Params.Title }} {{/* Handles any dashes in the title */}}
 {{ $slug = anchorize $slug }}
+{{ $slug = replaceRE `(-{2,})` "-" $slug }} {{/* Replaces multiple dashes with one */}}
 {{ if .NavPage.Params.Slug }}
     {{ $slug = .NavPage.Params.Slug}}
 {{ end }}
@@ -19,6 +20,7 @@
 {{/* Parent slug */}}
 {{ $parentSlug := ((humanize .NavPage.Parent.Params.Title) | default "root") }}
 {{ $parentSlug = anchorize $parentSlug }}
+{{ $parentSlug = replaceRE `(-{2,})` "-" $parentSlug }}
 {{ if .NavPage.Parent.Params.Slug }}
     {{ $parentSlug = .NavPage.Parent.Params.Slug}}
 {{ end }}

--- a/layouts/partials/searchmap-item.html
+++ b/layouts/partials/searchmap-item.html
@@ -13,6 +13,7 @@
 {{ with .Page}}
     {{ $slug := humanize .Params.Title }}
     {{ $slug = anchorize $slug }}
+    {{ $slug = replaceRE `(-{2,})` "-" $slug }} {{/* Replaces multiple dashes with one */}}
     {{ if .Params.Slug }}
         {{ $slug = .Params.Slug}}
     {{ end }}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -23,6 +23,8 @@
     {{/* Use title if no slug */}}
     {{ $slug := humanize $page.Params.Title }} {{/* Handles any dashes in the title */}}
     {{ $slug = anchorize $slug }}
+    {{ $slug = replaceRE `(-{2,})` "-" $slug }} {{/* Replaces multiple dashes with one */}}
+    
     {{ if $page.Params.Slug }}
         {{ $slug = $page.Params.Slug}}
     {{ end }}


### PR DESCRIPTION
Replaced multiple dashes in the slugs with a single dash. The multiple dashes broke links in the generated PDF.

### Issue
[PRSDM-3465](https://spandigital.atlassian.net/browse/PRSDM-3465)

### Testing
Create a PDF from a doc site that has glossary items with titles containing a space followed by a special character. For example "Apple Media Discovery (AMP)"

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)