### PR TITLE
Bugfix/prsdm 3522 expandable alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,7 @@
 ## 2023-02-15
 ### Bugfixes
 - Replace multiple dashes in slugs with one. @LantareCode https://spandigital.atlassian.net/browse/PRSDM-3465
+
+## 2023-02-16
+### Bugfixes
+- Made the article alert popup expandable to make sure text doesn't spill @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3522

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -69,7 +69,6 @@ body::after{
     color: white;
 
     width: 419px;
-    height: 44px;
 
     position: fixed;
     left: 50%;
@@ -85,7 +84,7 @@ body::after{
     text-align: center;
 
     .popup-text {
-        height: 20px;
+        margin: auto;
     }
 
     grid-template-columns: 40px auto 30px;
@@ -109,6 +108,8 @@ body::after{
         border-radius: 4px;
         height: 20px;
         line-height: 0;
+        margin: auto 0;
+
         border: none;
 
         background-color: white;
@@ -171,6 +172,7 @@ body::after{
     background-image: url('assets/svg/icon-alert.png');
     background-size: 20px 20px;
     background-repeat: no-repeat;
+    margin: auto 0;
 }
 
 .editor-options {


### PR DESCRIPTION
Made the popup alert expand if the text is long.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3522

### Screenshots
![image](https://user-images.githubusercontent.com/35559164/219310332-9b1b930c-326e-40eb-9054-27161da2dd80.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
