### PR TITLE
Techspike - Nav Lazyload

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,12 @@ module:
       target: archetypes
     - source: node_modules
       target: static/node_modules
-
+outputformats:
+  navigation:
+    basename: navigation
+    mediatype: text/javascript
+outputs:
+  home:
+  - Navigation
 params:
   favicon: images/favicon.ico

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,6 +15,10 @@
     {{ end }}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.js"></script>
+    {{ if $.Site.Params.lazyLoad }}
+      {{ $navUrl := path.Join .Site.BaseURL "/navigation.js"  }}
+      <script src="{{$navUrl}}"></script>
+    {{ end }}
 </head>
 
 <body id="presidium">
@@ -27,7 +31,13 @@
 
     <div class="content-wrapper">
       <div id="presidium-navigation">
-        {{ partialCached "navigation/root" . 0 }}
+        {{ if $.Site.Params.lazyLoad }}
+          <script>
+            $('#presidium-navigation').html(window.navigation);
+          </script>
+        {{ else }}
+          {{ partialCached "navigation/root" . 0 }}
+        {{ end }}
       </div>
   
       <div id="resizer"></div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.js"></script>
     {{ if $.Site.Params.lazyLoad }}
-      {{ $navUrl := path.Join .Site.BaseURL "/navigation.js"  }}
+      {{ $url := urls.Parse .Site.BaseURL }}
+      {{ $url = path.Clean $url.Path }}
+      {{ $navUrl := path.Join $url "/navigation.js"  }}
       <script src="{{$navUrl}}"></script>
     {{ end }}
 </head>

--- a/layouts/index.navigation.js
+++ b/layouts/index.navigation.js
@@ -1,1 +1,1 @@
-window.navigation = `{{ partial "navigation.html" . }}`;
+window.navigation = `{{ partial "navigation/root" . }}`;

--- a/layouts/index.navigation.js
+++ b/layouts/index.navigation.js
@@ -1,0 +1,1 @@
+window.navigation = `{{ partial "navigation.html" . }}`;


### PR DESCRIPTION
### Description
This PR is a tech spike for lazy loading the nav.
Summary;
When `lazyLoad` is enabled, it renders the nav to a `navigation.js` file which is then loaded and injected into the page before rendering. It removes the need to render and upload an entire site when an article is added, deleted, or renamed. 

Live on: https://eng.presidium.spandigital.io/

There is still some room for improvement. Here are a couple of issues I found
- The `navigation.js` file needs to be fetched before the page renders so it increases the page load time. This can be fixed by adjusting the API cache policy.;
- The JS media/mime type is OS-dependent. It needs to be set to `text/javascript` on MacOS but `application/javascript` on Linux. Haven't found a solution yet.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3493
