### PR TITLE
Fixed image shortcode in top level _index.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,7 @@
 ### Bugfixes
 - Fixed a bug where the WYSIWYG settings menu would disappear when all blocks were deleted @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3487
 - Replaced some SVG files with PNGs so that they will show up in the PDF. @LantareCode https://spandigital.atlassian.net/browse/PRSDM-3500
+
+## 2023-02-27
+### Bugfixes
+- Fixed a bug where image shortcodes in top level `_index.md` files using the `{{< img src="..." >}}` format threw and error, because `.Page.Parent.Parent` does not exist in that file. @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3563

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -4,10 +4,10 @@
 
 {{ if .Page.Parent.Resources.GetMatch $src }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.RelPermalink | default "") $src }}
-{{ else if .Page.Parent.Parent.Resources.GetMatch $src }}
+{{ else if and (.Page.Parent.Parent) (.Page.Parent.Parent.Resources.GetMatch $src) }}
     {{ $src = printf "%s/%s" (strings.TrimSuffix "/" .Page.Parent.Parent.RelPermalink | default "") $src }}
 {{ else if not $url.Scheme  }}
-    {{ $src = printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) $src }}  
+    {{ $src = printf "%s/%s" (strings.TrimSuffix "/" site.BaseURL) $src }}
 {{ end }}
 
 {{ $ignore := (slice "attrlink" "attr" "link" "alt" "caption" "title" "src")}}


### PR DESCRIPTION
Fixed image shortcode in top-level _index.md

### Description
Fixed a bug where image shortcodes in top-level `_index.md` files using the `{{< img src="..." >}}` format threw and error, because `.Page.Parent.Parent` does not exist in that file. Added a condition to check for `.Page.Parent.Parent`

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3563

### Testing
Before change, adding an image in the `{{< img src="..." >}}` format (not the `![...]({{% baseurl %}}/images/....png)` format) in a level `_index.md` file would break the site. After the change doing so works.

### Screenshots
![Screenshot 2023-02-27 at 20 10 53](https://user-images.githubusercontent.com/59831464/221647807-21c6db70-39d7-4c50-bea1-4f93fbdfbebc.png)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
