### PR TITLE
Fix .File.Filename warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,7 @@
 ## 2023-02-27
 ### Bugfixes
 - Fixed a bug where image shortcodes in top level `_index.md` files using the `{{< img src="..." >}}` format threw and error, because `.Page.Parent.Parent` does not exist in that file. @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3563
+
+## 2023-02-28
+### Bugfixes
+- Fixed this warning `.File.Filename on zero object. Wrap it in if or with: {{ with .File }}{{ .Filename }}{{ end }}` @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3569

--- a/layouts/partials/json-nav-item.html
+++ b/layouts/partials/json-nav-item.html
@@ -21,11 +21,11 @@
 {{ range .NavPage.Data.Pages}}
     {{ $children = $children | append (partial "json-nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" $childLevel )) }}
 {{ end }}
-{{ $base := dict "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug  }}
+{{ $currentPageFilename := "" }}
 {{ with .CurrentPage.File }}
-    {{ $base = $base | append (dict "current" .Filename) }}
+    {{ $currentPageFilename = .Filename }}
 {{ end }}
-{{ if $children }}
+{{ $base := dict "current" $currentPageFilename "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug }}{{ if $children }}
     {{ $base = merge $base (dict "children" $children) }}
 {{ end }}
 {{ if eq .Level 1 }}

--- a/layouts/partials/json-nav-item.html
+++ b/layouts/partials/json-nav-item.html
@@ -21,7 +21,10 @@
 {{ range .NavPage.Data.Pages}}
     {{ $children = $children | append (partial "json-nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" $childLevel )) }}
 {{ end }}
-{{ $base := dict "current" .CurrentPage.File.Filename "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug }}
+{{ $base := dict }}
+{{ with .CurrentPage.File }}
+    {{ $base = dict "current" .Filename "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug }}
+{{ end }}
 {{ if $children }}
     {{ $base = merge $base (dict "children" $children) }}
 {{ end }}

--- a/layouts/partials/json-nav-item.html
+++ b/layouts/partials/json-nav-item.html
@@ -21,9 +21,9 @@
 {{ range .NavPage.Data.Pages}}
     {{ $children = $children | append (partial "json-nav-item" (dict "CurrentPage" $currentPage "NavPage" . "Level" $childLevel )) }}
 {{ end }}
-{{ $base := dict }}
+{{ $base := dict "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug  }}
 {{ with .CurrentPage.File }}
-    {{ $base = dict "current" .Filename "type" $type "id" .NavPage.File.Filename "title" .NavPage.Title "level" .Level "collapsed" false  "path" .NavPage.File.Filename "url" $link "roles" (slice (.NavPage.Params.Roles | default "All Roles")) "scope" (slice) "slug" .NavPage.Params.Slug }}
+    {{ $base = $base | append (dict "current" .Filename) }}
 {{ end }}
 {{ if $children }}
     {{ $base = merge $base (dict "children" $children) }}


### PR DESCRIPTION
Fix the .File.Filename warning

### Description
Fix the .File.Filename warning for a zero object by using with

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3569

### Testing
Before the fix, run `hugo serve` on your docs of choice and see the error. After the fix do the same, but no warning now

### Screenshots
Before:
<img width="1426" alt="Screenshot 2023-02-28 at 08 24 23" src="https://user-images.githubusercontent.com/59831464/221772707-e689919a-608f-4cf6-9675-b17fc970e037.png">
After:
<img width="1438" alt="Screenshot 2023-02-28 at 08 24 34" src="https://user-images.githubusercontent.com/59831464/221772764-e25542af-d1d5-4da9-af15-3da933c6bb68.png">

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
