### PR TITLE
Override EditorJS styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,7 @@
 ## 2023-02-28
 ### Bugfixes
 - Fixed this warning `.File.Filename on zero object. Wrap it in if or with: {{ with .File }}{{ .Filename }}{{ end }}` @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3569
+
+## 2023-03-01
+### Bugfixes
+- Fixed a bug where the tune menu and popover would be placed off-screen when the viewport is narrow. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3225

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -28,13 +28,20 @@ body::after{
     display: none;
 }
 
-.ce-toolbar__actions {
-    right: 100%;
-    top: -2px;
+@media (max-width: 768px) {
+    .ce-toolbar__actions {
+        right: 0px !important; // Place the tune menu on the right side of the screen when it's narrow
+    }
+}
+
+@media (min-width: 768px) {
+    .codex-editor--narrow .ce-toolbox .ce-popover {
+        right: -140px !important; // Prevent the popover from being obscured by the navbar
+    }
 }
 
 .ce-toolbar__settings-btn--hidden {
-    display: flex; // Override `display: none;`. Don't remove options
+    display: flex; // Override `display: none;`. Don't remove options https://github.com/SPANDigital/presidium-theme-website/pull/186
 }
 
 .editor-button {

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -34,6 +34,12 @@ body::after{
     }
 }
 
+@media (max-width: 768px) {
+    .ce-popover {
+        right: -50px !important; // Prevent the popover from being obscured by the navbar
+    }
+}
+
 @media (min-width: 768px) {
     .codex-editor--narrow .ce-toolbox .ce-popover {
         right: -140px !important; // Prevent the popover from being obscured by the navbar

--- a/assets/_sass/_editor.scss
+++ b/assets/_sass/_editor.scss
@@ -36,7 +36,7 @@ body::after{
 
 @media (max-width: 768px) {
     .ce-popover {
-        right: -50px !important; // Prevent the popover from being obscured by the navbar
+        right: -50px !important; // Prevent the popover from being pushed off the right side of the screen
     }
 }
 


### PR DESCRIPTION
Fixed a bug where the tune menu and popover would be placed off-screen when the viewport is narrow.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3225

### Testing
<!-- Provide QA steps -->

### Screenshots
<img width="432" alt="Screenshot 2023-03-02 at 07 40 34" src="https://user-images.githubusercontent.com/35559164/222342454-2e0e104b-b452-41b5-bb7e-e6d96f36a200.png">

<img width="318" alt="image" src="https://user-images.githubusercontent.com/35559164/222342728-30379952-99b8-410d-97df-94557a96f72d.png">


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
