### PR TITLE
Flatten searchmap by appending returned searchmap item individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,7 @@
 ## 2023-03-01
 ### Bugfixes
 - Fixed a bug where the tune menu and popover would be placed off-screen when the viewport is narrow. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3225
+
+## 2023-03-13
+### Bugfixes
+- Ensure searchmap is flattened to prevent breaking search upload. @ChrisB https://spandigital.atlassian.net/browse/PRSDM-3618

--- a/layouts/partials/searchmap/root.html
+++ b/layouts/partials/searchmap/root.html
@@ -4,7 +4,9 @@
 {{ range $menu := .Site.Menus.main.ByWeight }}
     {{ $urilzeIdentifier = $menu.Identifier | urlize  }}
     {{ with $.Site.GetPage "section" $urilzeIdentifier }}
-        {{ $items = $items | append (partial "searchmap/item" (dict "Page" . "Level" 1) )}}
+        {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1) )}}
+            {{ $items = $items | append $searchmapItem }}
+        {{ end }}
     {{ end }}
 {{ end }}
 {{ return $items }}


### PR DESCRIPTION

### Description
The Searchmap has nested values that is breaking the search import. This is only breaking on Chronicle and we cannot find the bug as we suspect it is in hugo.

This fix flattens the returned slice through a simple iteration append.

### Issue
[<!-- JIRA link -->](https://spandigital.atlassian.net/browse/PRSDM-3618)

### Testing

### Screenshots

A simple view with this fix. Indentation implies depth/ nesting.

```
    "section": "Meetups",
    "section": "Meetups",
    "section": "Meetups",
    "section": "Meetups",
    "section": "Case Studies",
    "section": "Case Studies",
```
Without fix:

```
    "section": "Meetups",
    "section": "Meetups",
      "section": "Case Studies", // <-- see indentation
      "section": "Case Studies",
```

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
