### PR TITLE
fix(wysiwyg): remove section from styles

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -65,305 +65,303 @@
       font-weight: normal;
     }
 
-    section {
-      #no-content-warning {
-        display: none;
+    #no-content-warning {
+      display: none;
+    }
+    span.anchor {
+      display: block;
+      position: relative;
+      top: -50px;
+      visibility: hidden;
+    }
+
+    .article-options {
+      position: absolute;
+      padding: 0px 20px;
+      top: 12px;
+      left: -70px;
+      height: 100%;
+
+      @media (max-width: $grid-float-breakpoint) {
+        left: unset;
+        right: 0px;
       }
-      span.anchor {
-        display: block;
-        position: relative;
-        top: -50px;
-        visibility: hidden;
+    }
+
+    .article-title {
+      display: flex;
+      align-items: center;
+
+      @media (max-width: $grid-float-breakpoint) {
+        max-width: calc(100vw - 120px);
       }
 
-      .article-options {
-        position: absolute;
-        padding: 0px 20px;
-        top: 12px;
-        left: -70px;
-        height: 100%;
-
-        @media (max-width: $grid-float-breakpoint) {
-          left: unset;
-          right: 0px;
+      @include headings {
+        &:hover {
+          cursor: pointer;
+          .article-edit-menu {
+            pointer-events: all;
+            opacity: 1;
+          }
         }
       }
 
-      .article-title {
+      .permalink {
+        display: none;
+        margin-left: 12px;
+        margin-top: 14px;
+      }
+
+      &:hover > .permalink {
+        display: block;
+        > a {
+          text-decoration: none;
+        }
+      }
+    }
+
+    .article-status {
+      .status-draft,
+      .status-review,
+      .status-published,
+      .status-retired {
+        background-repeat: no-repeat;
+        background-position: left;
+        background-size: 24px 19px;
+        padding: 2px 2px 2px 31px;
+        background-color: unset;
+      }
+
+      .status-draft {
+        background-image: url('images/status-draft.png');
+        color: $color-yellow-green;
+      }
+      .status-review {
+        background-image: url('images/status-review.png');
+        color: $color-yellow-green;
+      }
+      .status-published {
+        background-image: url('images/status-published.png');
+        color: $color-green;
+      }
+      .status-retired {
+        background-image: url('images/status-retired.png');
+        color: $color-grey;
+      }
+    }
+
+    .category {
+      a > span {
+        padding-left: 10px;
+        color: $link-color;
+        font-size: 80%;
+      }
+    }
+
+    .article-header {
+      width: 100%;
+      padding: 10px 0;
+      > div {
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: 10px;
+        &:first-child {
+          margin-left: 0px;
+        }
+        .label {
+          line-height: 15px;
+        }
+      }
+
+      .article-role {
+        float: right;
+        .label {
+          background-image: url('images/role-icon.svg');
+          background-repeat: no-repeat;
+          background-size: 25px 15px;
+          background-color: unset;
+          background-position: left center;
+          color: $color-grey;
+          line-height: 18px;
+          padding: 2px 2px 2px 33px;
+        }
+      }
+    }
+
+    .article-author {
+      a {
+        text-decoration: underline;
+        color: $color-grey;
+
+        &:hover {
+          color: $navbar-default-link-hover-color;
+        }
+      }
+    }
+
+    .article {
+      .presidium-article-wrapper {
+        > article + .article.child {
+          margin-top: 20px;
+        }
+      }
+
+      .article-edit-menu {
+        display: flex;
+        flex-direction: column;
+        margin-left: 15px;
+        opacity: 0;
+        transition: opacity 0.3s;
+        pointer-events: none;
+        position: relative;
+        background: #f9f8f8;
+        padding: 1px 13px;
+        border-radius: 10px;
+        &:after {
+          right: 100%;
+          top: 50%;
+          border: solid transparent;
+          content: ' ';
+          height: 0;
+          width: 0;
+          position: absolute;
+          pointer-events: none;
+          border-color: rgba(212, 212, 212, 0);
+          border-right-color: #f9f8f8;
+          border-width: 15px;
+          margin-top: -15px;
+        }
+      }
+
+      .dropdown-item {
         display: flex;
         align-items: center;
-
-        @media (max-width: $grid-float-breakpoint) {
-          max-width: calc(100vw - 120px);
-        }
-
-        @include headings {
-          &:hover {
-            cursor: pointer;
-            .article-edit-menu {
-              pointer-events: all;
-              opacity: 1;
-            }
-          }
-        }
-
-        .permalink {
-          display: none;
-          margin-left: 12px;
-          margin-top: 14px;
-        }
-
-        &:hover > .permalink {
-          display: block;
-          > a {
-            text-decoration: none;
-          }
+        flex: 1;
+        padding: 1px;
+        &:hover {
+          text-decoration: none;
         }
       }
 
-      .article-status {
-        .status-draft,
-        .status-review,
-        .status-published,
-        .status-retired {
-          background-repeat: no-repeat;
-          background-position: left;
-          background-size: 24px 19px;
-          padding: 2px 2px 2px 31px;
-          background-color: unset;
-        }
-
-        .status-draft {
-          background-image: url('images/status-draft.png');
-          color: $color-yellow-green;
-        }
-        .status-review {
-          background-image: url('images/status-review.png');
-          color: $color-yellow-green;
-        }
-        .status-published {
-          background-image: url('images/status-published.png');
-          color: $color-green;
-        }
-        .status-retired {
-          background-image: url('images/status-retired.png');
-          color: $color-grey;
-        }
+      .edit-icon {
+        background-image: url('assets/svg/edit-icon.svg');
+        fill: #9a9a99;
+        width: 16px;
+        height: 16px;
       }
 
-      .category {
-        a > span {
-          padding-left: 10px;
-          color: $link-color;
-          font-size: 80%;
-        }
+      .link-icon {
+        background-image: url('assets/svg/link-icon.svg');
+        fill: #9a9a99;
+        width: 16px;
+        height: 16px;
+        display: block;
+      }
+    }
+
+    figure {
+      margin-bottom: 24px;
+    }
+
+    article {
+      > div {
+        overflow-x: auto;
       }
 
-      .article-header {
-        width: 100%;
-        padding: 10px 0;
-        > div {
-          display: inline-block;
-          vertical-align: middle;
-          margin-left: 10px;
-          &:first-child {
-            margin-left: 0px;
-          }
-          .label {
-            line-height: 15px;
-          }
-        }
-
-        .article-role {
-          float: right;
-          .label {
-            background-image: url('images/role-icon.svg');
-            background-repeat: no-repeat;
-            background-size: 25px 15px;
-            background-color: unset;
-            background-position: left center;
-            color: $color-grey;
-            line-height: 18px;
-            padding: 2px 2px 2px 33px;
-          }
-        }
+      iframe {
+        box-shadow: 0px 0px 10px #777;
+        border: None;
       }
 
-      .article-author {
+      @include headings {
+        text-transform: none;
+        margin-top: 20px;
+        margin-bottom: 10px;
+      }
+
+      .presidium-pro-tip,
+      .presidium-prerequisite,
+      .presidium-for-example,
+      .presidium-suggested-reading,
+      .presidium-suggested-courses,
+      .presidium-best-practice,
+      .presidium-warning,
+      .presidium-chris-says {
+        padding: 9px 10px 10px;
+        margin-bottom: 10px;
+        border: 2px solid;
+        border-radius: 4px;
+        font-style: normal;
+
+        em {
+          font-weight: bold;
+          font-style: normal;
+        }
+
         a {
           text-decoration: underline;
           color: $color-grey;
-
-          &:hover {
-            color: $navbar-default-link-hover-color;
-          }
-        }
-      }
-
-      .article {
-        .presidium-article-wrapper {
-          > article + .article.child {
-            margin-top: 20px;
-          }
         }
 
-        .article-edit-menu {
+        span {
+          font-size: 18px;
+          line-height: 21px;
+          font-weight: 500;
+          letter-spacing: 0;
+          margin-bottom: 4px;
           display: flex;
-          flex-direction: column;
-          margin-left: 15px;
-          opacity: 0;
-          transition: opacity 0.3s;
-          pointer-events: none;
-          position: relative;
-          background: #f9f8f8;
-          padding: 1px 13px;
-          border-radius: 10px;
-          &:after {
-            right: 100%;
-            top: 50%;
-            border: solid transparent;
-            content: ' ';
-            height: 0;
-            width: 0;
-            position: absolute;
-            pointer-events: none;
-            border-color: rgba(212, 212, 212, 0);
-            border-right-color: #f9f8f8;
-            border-width: 15px;
-            margin-top: -15px;
-          }
         }
 
-        .dropdown-item {
+        &::before {
           display: flex;
-          align-items: center;
-          flex: 1;
-          padding: 1px;
-          &:hover {
-            text-decoration: none;
-          }
-        }
-
-        .edit-icon {
-          background-image: url('assets/svg/edit-icon.svg');
-          fill: #9a9a99;
-          width: 16px;
-          height: 16px;
-        }
-
-        .link-icon {
-          background-image: url('assets/svg/link-icon.svg');
-          fill: #9a9a99;
-          width: 16px;
-          height: 16px;
-          display: block;
+          font-size: 13px;
+          font-weight: 500;
+          letter-spacing: 0;
+          line-height: 15px;
+          text-transform: uppercase;
+          margin-bottom: 4px;
         }
       }
 
-      figure {
-        margin-bottom: 24px;
+      .presidium-pro-tip {
+        @include callout($color-orange, 'span pro tip');
       }
 
-      article {
-        > div {
-          overflow-x: auto;
-        }
+      .presidium-for-example {
+        @include callout($color-green, 'for example...');
+      }
 
-        iframe {
-          box-shadow: 0px 0px 10px #777;
-          border: None;
-        }
+      .presidium-suggested-reading {
+        @include callout($color-blue, 'suggested reading');
+      }
 
-        @include headings {
-          text-transform: none;
-          margin-top: 20px;
-          margin-bottom: 10px;
-        }
+      .presidium-suggested-courses {
+        @include callout($color-blue, 'suggested courses');
+      }
 
-        .presidium-pro-tip,
-        .presidium-prerequisite,
-        .presidium-for-example,
-        .presidium-suggested-reading,
-        .presidium-suggested-courses,
-        .presidium-best-practice,
-        .presidium-warning,
-        .presidium-chris-says {
-          padding: 9px 10px 10px;
-          margin-bottom: 10px;
-          border: 2px solid;
-          border-radius: 4px;
-          font-style: normal;
+      .presidium-best-practice {
+        @include callout($color-orange, 'best practice');
+      }
 
-          em {
-            font-weight: bold;
-            font-style: normal;
-          }
+      .presidium-warning {
+        @include callout($color-red, 'warning');
+      }
 
-          a {
-            text-decoration: underline;
-            color: $color-grey;
-          }
+      .presidium-prerequisite {
+        @include callout($color-yellow-green, 'prerequisite');
+      }
 
-          span {
-            font-size: 18px;
-            line-height: 21px;
-            font-weight: 500;
-            letter-spacing: 0;
-            margin-bottom: 4px;
-            display: flex;
-          }
+      .presidium-chris-says {
+        background-color: #000000;
+        border-color: #000000;
+        background-image: url('images/pentagram-symbol.svg');
+        color: $color-grey-2;
+        background-repeat: no-repeat;
+        background-position: top right;
+        background-size: 31px;
+        background-origin: content-box;
 
-          &::before {
-            display: flex;
-            font-size: 13px;
-            font-weight: 500;
-            letter-spacing: 0;
-            line-height: 15px;
-            text-transform: uppercase;
-            margin-bottom: 4px;
-          }
-        }
-
-        .presidium-pro-tip {
-          @include callout($color-orange, 'span pro tip');
-        }
-
-        .presidium-for-example {
-          @include callout($color-green, 'for example...');
-        }
-
-        .presidium-suggested-reading {
-          @include callout($color-blue, 'suggested reading');
-        }
-
-        .presidium-suggested-courses {
-          @include callout($color-blue, 'suggested courses');
-        }
-
-        .presidium-best-practice {
-          @include callout($color-orange, 'best practice');
-        }
-
-        .presidium-warning {
-          @include callout($color-red, 'warning');
-        }
-
-        .presidium-prerequisite {
-          @include callout($color-yellow-green, 'prerequisite');
-        }
-
-        .presidium-chris-says {
-          background-color: #000000;
-          border-color: #000000;
-          background-image: url('images/pentagram-symbol.svg');
-          color: $color-grey-2;
-          background-repeat: no-repeat;
-          background-position: top right;
-          background-size: 31px;
-          background-origin: content-box;
-
-          @include callout($color-grey-2, 'chris says...');
-        }
+        @include callout($color-grey-2, 'chris says...');
       }
     }
 


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
The `<section>` was recently removed with the refactor but there were still some styles that referenced it. I removed the `section` selection from the styles to fix the icon alignment.

I also logged a follow-up ticket to move the article option styles from the theme to enterprise: https://spandigital.atlassian.net/browse/PRSDM-3707

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3704

