### PR TITLE
fix(baseurl): remove shortcode spacing

### DIFF
--- a/layouts/shortcodes/baseurl.html
+++ b/layouts/shortcodes/baseurl.html
@@ -1,2 +1,2 @@
-{{ $url := urls.Parse .Site.BaseURL }}
-{{ path.Clean $url.Path }}
+{{- $url := urls.Parse .Site.BaseURL -}}
+{{- path.Clean $url.Path -}}

--- a/layouts/shortcodes/path.html
+++ b/layouts/shortcodes/path.html
@@ -1,1 +1,1 @@
-{{strings.TrimSuffix "/" .Page.Parent.RelPermalink | default "" }}
+{{- strings.TrimSuffix "/" .Page.Parent.RelPermalink | default "" -}}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Updated the baseurl and path shortcodes to remove the newlines. It broke the link rendering when the shortcode is used inside a table ref

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3777
