### PR TITLE
fix: align permalink anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,3 +101,7 @@
 ## 2023-03-13
 ### Bugfixes
 - Ensure searchmap is flattened to prevent breaking search upload. @ChrisB https://spandigital.atlassian.net/browse/PRSDM-3618
+
+## 2023-04-26
+### Bugfixes
+- Fixed the alignment of the Permalink icon. @mpilo-khathwane  https://spandigital.atlassian.net/browse/PRSDM-3818

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -110,7 +110,7 @@
         .permalink {
           display: none;
           margin-left: 12px;
-          margin-top: 14px;
+          margin-bottom: 8px;
         }
 
         &:hover > .permalink {


### PR DESCRIPTION
### Description
This PR fixes the alignment of the anchor tag for the Permalink.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3818

### Screenshots
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/20880250/234515049-ded2d756-f8a5-4077-a4dc-ea24731f6df6.png">

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
