### PR TITLE
Fix UI Overlap glitch in Export Project as PDF feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,7 @@
 ## 2023-04-26
 ### Bugfixes
 - Fixed the alignment of the Permalink icon. @mpilo-khathwane  https://spandigital.atlassian.net/browse/PRSDM-3818
+
+## 2023-05-09
+### Bugfixes
+- Fixed the UI Overlap glitch in Export Project as PDF dropdown button. @CharlRitter  https://spandigital.atlassian.net/browse/PRSDM-2952

--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -91,7 +91,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         background-color: #fff;
         border-radius: $border-radius-base;
         border: 1px solid $border;
-        -webkit-box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25); 
+        -webkit-box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25);
         box-shadow: 9px 5px 14px -4px rgba(0,0,0,0.25);
       }
     }
@@ -159,7 +159,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
           font-family: $primary-font-family;
           text-transform: none;
           text-align: center;
-  
+
           @media (max-width: $grid-float-breakpoint) {
             display: none; //hidden by default
             float: left;
@@ -169,7 +169,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
             @include navbar-vertical-align(14px);
           }
         }
-        
+
         .dropdown {
           display: block;
           z-index: $zindex-navbar;
@@ -210,7 +210,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
           .dropdown__control--is-selected .dropdown__dropdown-indicator > svg {
             fill: $brand-primary;
           }
-          .dropdown__value-container {
+          .dropdown__single-value, .dropdown__placeholder {
             display: none;
           }
         }
@@ -389,7 +389,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         > div > a {
           color: $brand-primary;
         }
-        
+
         &.child .add-icon,
           &.closed .add-icon {
           background-image: url('assets/svg/plus-white.svg');


### PR DESCRIPTION
Fix UI Overlap glitch in Export Project as PDF feature

### Description
The dropdown button uses a form dropdown input component package. The styling added in the theme broke the default behaviour to close the dropdown with a click external to the dropdown. Moving the culprit CSS to the child class did the trick.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2952

### Testing
Go into any project. Click the download as PDF button. Observe that it no longer persists and closes when clicking elsewhere.

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
