### PR TITLE
Add a shortcode for iframes, to lazy load them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,7 @@
 ## 2023-05-09
 ### Bugfixes
 - Fixed the UI Overlap glitch in Export Project as PDF dropdown button. @CharlRitter  https://spandigital.atlassian.net/browse/PRSDM-2952
+
+## 2023-05-10
+### Updates
+- Add a shortcode for iframes, to lazy load them. @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3870

--- a/layouts/shortcodes/iframe.html
+++ b/layouts/shortcodes/iframe.html
@@ -1,0 +1,8 @@
+{{ $attrs := ""}}
+{{ range $key, $value :=  .Params}}
+        {{ $attrs = (printf "%s=\"%s\" %s" $key $value $attrs) | safeHTMLAttr}}
+{{ end }}
+{{ $text := .Inner }}
+
+
+<iframe {{ $attrs }} loading="lazy" scrolling="no" framespacing="0" webkitallowfullscreen mozallowfullscreen allowfullscreen>{{ $text }}</iframe>


### PR DESCRIPTION
*NOTE* There seems to still be some jumping, although to a much smaller degree.

Add a shortcode for iframes, to lazy load them

### Description
Add a shortcode for iframes, to lazy load them

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3870

### Testing
http://localhost:8081/docs/span-handbook-draft/span-approach/05-project-artifacts/ has a lot of iframes, go there and see how they load and interact with the page. Compare the SPAN-Approach-2.0 handbook branch with the SPAN-Approach-2.0-test branch

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
