### PR TITLE
feat(archive): Moving article table to a a partial for extensibilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,3 +113,7 @@
 ## 2023-05-10
 ### Updates
 - Add a shortcode for iframes, to lazy load them. @CharlRitter https://spandigital.atlassian.net/browse/PRSDM-3870
+
+## 2023-05-17
+### Updates
+- Add a partial for archive table contents. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3804

--- a/layouts/partials/archive/table.html
+++ b/layouts/partials/archive/table.html
@@ -1,0 +1,5 @@
+<p class="archive-item"><strong>Date</strong> <strong>Title</strong></p>
+<hr>
+{{ range $page := .Pages }}
+    <p class="archive-item"> {{ .Date.Format "2 Jan 2006" }} <a href="{{ $page.Permalink }}">{{ $page.Name }}</a></p>
+{{ end }}

--- a/layouts/partials/common/archive.html
+++ b/layouts/partials/common/archive.html
@@ -1,4 +1,3 @@
-
 {{ $pages := where $.Site.AllPages ".IsPage" true }}
 {{ if and $.Site.Params.archive (ne $.Site.Params.archive.age 0)}}
     {{ $age := mul 86400 $.Site.Params.archive.age }}
@@ -8,12 +7,6 @@
 
     <div class="archive">
         <h1>Archive</h1>
-        <p class="archive-item"> <strong>Date</strong> <strong>Title</strong></p>
-        <hr>
-        {{ range $page := $pages }}
-            <p class="archive-item"> {{ .Date.Format "2 Jan 2006" }} <a href="{{ $page.Permalink }}">{{ $page.Name }}</a></p>
-            <hr>
-        {{ end }}
+        {{ partial "archive/table" (dict "NavPage" . "Pages" $pages) }}
     </div>
 {{ end }}
-


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
Refactors archive table content to a partial.

### Description
The SPAN Chronicles archive table required additional information about the section that the archived article belonged to for context. The current archive table is not extensible / customisable.

This moves archive table content to a partial `archive/table` that can be overriden for custom archive layouts.


### Issue
[PRSDM-3804](https://spandigital.atlassian.net/browse/PRSDM-3804)
- Associated changes `span-chronicle-docs`: [PR](https://github.com/SPANDigital/span-chronicle-docs/pull/16)

### Testing
<!-- Provide QA steps -->

### Screenshots

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
