### PR TITLE
feat(pages): Adding a target minimum number of articles in sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,7 @@
 ## 2023-05-17
 ### Updates
 - Add a partial for archive table contents. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3804
+
+## 2023-05-18
+### Updates
+- Updated list pages to be able to include archived articles to maintain a minimum number of displayed articles @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3803

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -1,8 +1,20 @@
 {{/*  Returns the pages after filtering out the archived articles  */}}
-{{ $pages := .Data.Pages }}
+{{ $pages := .Pages }}
 {{ if and $.Site.Params.archive (ne $.Site.Params.archive.age 0)}}
     {{ $age := mul 86400 $.Site.Params.archive.age }}
     {{ $before := sub now.Unix $age }}
-    {{ $pages = where .Data.Pages "Date.Unix" "gt" $before }}
+    {{ $activePages := (where .RegularPages "Date.Unix" "gt" $before) }}
+
+    {{/* show a limited number (unarchived + archived) items if there are too few active articles in section */}}
+    {{ $items := $.Site.Params.section.items }}
+    {{ $isArchives := and (isset $.Site.Params.section "items") (not (ge (len $activePages) $items)) }}
+    {{ $pages = cond $isArchives (first $items .RegularPages.ByDate.Reverse) $activePages }}
+
+    {{/* retain subsection pages which have active children articles */}}
+    {{ range .Sections }}
+        {{ $hasChildren := gt (index .Pages.ByDate.Reverse 0).Date.Unix $before }}
+        {{ $pages = cond (or $hasChildren $isArchives) ($pages | append .) $pages }}
+    {{ end }}
+
 {{ end }}
 {{ return $pages }}

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -10,11 +10,7 @@
     {{ $isArchives := and (isset $.Site.Params.section "items") (not (ge (len $activePages) $items)) }}
     {{ $pages = cond $isArchives (first $items .RegularPages.ByDate.Reverse) $activePages }}
 
-    {{/* retain subsection pages which have active children articles */}}
-    {{ range .Sections }}
-        {{ $hasChildren := gt (index .Pages.ByDate.Reverse 0).Date.Unix $before }}
-        {{ $pages = cond (or $hasChildren $isArchives) ($pages | append .) $pages }}
-    {{ end }}
-
+    {{/* retain nested sections */}}
+    {{ $pages = cond $isArchives ($pages | append .Sections) $pages }}
 {{ end }}
 {{ return $pages }}

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -6,11 +6,12 @@
     {{ $activePages := (where .RegularPages "Date.Unix" "gt" $before) }}
 
     {{/* show a limited number (unarchived + archived) items if there are too few active articles in section */}}
+    {{ $isItems := isset $.Site.Params.section "items" }}
     {{ $items := $.Site.Params.section.items }}
-    {{ $isArchives := and (isset $.Site.Params.section "items") (not (ge (len $activePages) $items)) }}
-    {{ $pages = cond $isArchives (first $items .RegularPages.ByDate.Reverse) $activePages }}
+    {{ $showItems := and $isItems (not (ge (len $activePages) $items)) }}
+    {{ $pages = cond $showItems (first $items .RegularPages.ByDate.Reverse) $activePages }}
 
     {{/* retain nested sections */}}
-    {{ $pages = cond $isArchives ($pages | append .Sections) $pages }}
+    {{ $pages = cond $isItems ($pages | append .Sections) $pages }}
 {{ end }}
 {{ return $pages }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
Adds a configurable target minimum number of articles to be displayed per subsection in the menu, including archived articles if necessary.

### Description
SPAN Chronicles list pages should be able to configure a (targeted) minimum number of articles. This is to maintain some visibility of articles in sections which may not be updated with content regularly whose content may expire.

This adds logic to `common/pages` to update the archiving / displayed articles logic to allow showing archived articles if there aren't enough active articles in the section.
- _**NOTE**: This also fixes an issue that was discovered with diaply page caulations not taking into account section pages. Once archiving was set > 0days, all subfolders were not displayed, even if the articles they contained were not archived._

This logic behind this is:
```
# c: current (unarchived) articles in section
# a: archived articles in section
# M: Targeted minimum article count to display

if c < M:
   display M latest articles (combination of all(c) + newest(a))
else: 
    display c only
```

- Adds `sections.items` param to `config.yaml` to configure the desired minimum number of items displayed poer section.
- Requires `archive.age` to be > 0
 eg. The following config would display up to 5 archived articles per section, assuming the active article count for that section is < 5
    ```
    params:
      archive:
        path: archive/index.md
        age: 365
      section:
        items: 5
    ```


### Issue
[PRSDM-3803](https://spandigital.atlassian.net/browse/PRSDM-3803)

### Testing
<!-- Provide QA steps -->

### Screenshots
1. No archiving, section.items is redundant
```
params:
  archive:
    age: 0
  section:
    items: 5
```
![Screenshot 2023-05-18 at 14 39 08](https://github.com/SPANDigital/presidium-theme-website/assets/57132358/1ee7b121-56b6-4f40-bebd-221152bc4adf)

2. Archiving enabled
```
params:
  archive:
    age: 9
  section:
    items: 5
```
![Screenshot 2023-05-18 at 14 55 23](https://github.com/SPANDigital/presidium-theme-website/assets/57132358/e27e0130-566a-4d59-99b5-0d99445fcf5e)


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
