### PR TITLE
fix(pages): Fix build error when permitted archive exposure param not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,3 +121,7 @@
 ## 2023-05-18
 ### Updates
 - Updated list pages to be able to include archived articles to maintain a minimum number of displayed articles @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3803
+
+## 2023-05-25
+### Bugfixes
+- Fixed build error when archive age is set but maximum number of permitted archives to display is unset in site params @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3940

--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -16,7 +16,7 @@
 {{ $uid := .File.UniqueID }}
 
 <div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}">
-    {{ if or (ne (len .Content) 0) (and $nestedArticles .Data.Pages) }}
+    {{ if or (ne (len .Content) 0) (and $nestedArticles (partial "common/pages" .)) }}
         <div class="presidium-article-wrapper">
             <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>
             {{ partial "article/header" . }}

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -1,16 +1,18 @@
 {{/*  Returns the pages after filtering out the archived articles  */}}
 {{ $pages := .Pages }}
-{{ if and $.Site.Params.archive (ne $.Site.Params.archive.age 0)}}
-    {{ $age := mul 86400 $.Site.Params.archive.age }}
+{{ if and .Site.Params.archive (ne .Site.Params.archive.age 0)}}
+    {{ $age := mul 86400 .Site.Params.archive.age }}
     {{ $before := sub now.Unix $age }}
-    {{ $pages = (where .RegularPages "Date.Unix" "gt" $before)}}
+    {{ $pages = (where .Pages "Date.Unix" "gt" $before)}}
 
     {{/* expose a limited number of exposed archive items if there are too few active articles */}}
-    {{ if (ne ($.Site.Params.archive.expose | default 0) 0)}}
-        {{ $expose := $.Site.Params.archive.expose }}
-        {{ $showItems := not (ge (len $pages) $expose) }}
-        {{ $pages = cond $showItems (first $expose .RegularPages.ByDate.Reverse) $pages }}
+    {{ $expose := $.Site.Params.archive.expose | default 0}}
+    {{ $isExposing := and (ne $expose 0) (not (ge (len $pages) $expose))}}
+    {{ if $isExposing }}
+        {{ $archives := first (sub $expose (len $pages)) (complement $pages .RegularPages) }}
+        {{ $pages = $pages | append $archives }}
     {{end}}
+    {{/* retain subsections */}}
     {{ $pages = $pages | append .Sections }}
 {{ end }}
 {{ return $pages }}

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -3,15 +3,14 @@
 {{ if and $.Site.Params.archive (ne $.Site.Params.archive.age 0)}}
     {{ $age := mul 86400 $.Site.Params.archive.age }}
     {{ $before := sub now.Unix $age }}
-    {{ $activePages := (where .RegularPages "Date.Unix" "gt" $before) }}
+    {{ $pages = (where .RegularPages "Date.Unix" "gt" $before)}}
 
-    {{/* show a limited number (unarchived + archived) items if there are too few active articles in section */}}
-    {{ $isItems := isset $.Site.Params.section "items" }}
-    {{ $items := $.Site.Params.section.items }}
-    {{ $showItems := and $isItems (not (ge (len $activePages) $items)) }}
-    {{ $pages = cond $showItems (first $items .RegularPages.ByDate.Reverse) $activePages }}
-
-    {{/* retain nested sections */}}
-    {{ $pages = cond $isItems ($pages | append .Sections) $pages }}
+    {{/* expose a limited number of exposed archive items if there are too few active articles */}}
+    {{ if (ne ($.Site.Params.archive.expose | default 0) 0)}}
+        {{ $expose := $.Site.Params.archive.expose }}
+        {{ $showItems := not (ge (len $pages) $expose) }}
+        {{ $pages = cond $showItems (first $expose .RegularPages.ByDate.Reverse) $pages }}
+    {{end}}
+    {{ $pages = $pages | append .Sections }}
 {{ end }}
 {{ return $pages }}

--- a/layouts/partials/common/pages.html
+++ b/layouts/partials/common/pages.html
@@ -1,7 +1,7 @@
 {{/*  Returns the pages after filtering out the archived articles  */}}
 {{ $pages := .Pages }}
-{{ if and .Site.Params.archive (ne .Site.Params.archive.age 0)}}
-    {{ $age := mul 86400 .Site.Params.archive.age }}
+{{ if and $.Site.Params.archive (ne $.Site.Params.archive.age 0)}}
+    {{ $age := mul 86400 $.Site.Params.archive.age }}
     {{ $before := sub now.Unix $age }}
     {{ $pages = (where .Pages "Date.Unix" "gt" $before)}}
 


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
Fixes build error when permitted archive exposure param not set.

### Description
<!-- A longer description of the change -->
Logic in `common/pages` caused build errors when `archive.age` > 0 but `section.items` was not set.

Introduced in this [PR](https://github.com/SPANDigital/presidium-theme-website/pull/209).

This introduces a default when the parameter is missing to prevent the error.

- Also: renamed the number of archived articles permitted to be exposed from `Params.section.items` to `Params.archive.expose`


### Issue
[PRSDM-3940](https://spandigital.atlassian.net/browse/PRSDM-3940)

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
