### PR TITLE
Expose the index.md file to WYSIWYG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-static/node_modules
+**/node_modules
 .idea/
 resources/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,7 @@
 ## 2023-05-25
 ### Bugfixes
 - Fixed build error when archive age is set but maximum number of permitted archives to display is unset in site params @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3940
+
+## 2023-05-29
+### Updatess
+- Expose the index.md file to WYSIWYG

--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -1,13 +1,15 @@
 {{ $roles := .Params.roles | default "All Roles" }}
 {{ $slug := (partial "common/slug" .) }}
 
-{{ $nestedArticles := .Site.Params.includeNestedArticles | default true }}
+{{ $isTopLevelIndex := and ( strings.HasSuffix .File.Path "_index.md" ) (eq .Parent.File.Dir "")}}
+{{ $nestedArticles := and (.Site.Params.includeNestedArticles | default true) (not $isTopLevelIndex) }}
+{{ $nestedArticles = and $nestedArticles (gt (len .Data.Pages) 0)}}
 
 {{ $articleLink := (printf "%v#%v" .Parent.Page.RelPermalink $slug ) }}
 {{ $.Scratch.Set "articleLink" $articleLink }}
 
 {{/*  Type of article  */}}
-{{ $type := cond (not .Data.Pages) "child" "parent" }}
+{{ $type := cond $nestedArticles "parent" "child" }}
 
 {{/* Unique id for this article */}}
 {{ $articleId := .Params.id | default .File.Path }}

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -1,7 +1,7 @@
 {{ $slug := (partial "common/slug" .) }}
 {{ $articleLink := ($.Scratch.Get "articleLink") }}
 
-{{ if (eq .Parent.Title .Title) }}
+{{ if or (eq .Parent.Title .Title) .IsSection }}
 {{/*  No title - For when the main title is the same as the first article  */}}
 {{ else }}
     <div class="article-title article-actions" data-align="center-left">
@@ -10,7 +10,7 @@
         {{ else }}
             <h2> {{ .Title }}</h2>
         {{ end }}
-                
+
         <div class="permalink">
             <a style="cursor:pointer;" onclick="copyPermalink( {{ $articleLink }} )" id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}" class="link-icon" title="Permalink to this article"></a>
         </div>

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -1,4 +1,5 @@
-{{.Content}}
+
+{{ partial "article/root" . }}
 {{ $pages := (partial "common/pages" .) }}
 {{ $siteScopes := .Site.Params.scopes }}
 {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
@@ -12,7 +13,7 @@
         {{ if $siteScopesEnabled }}
             {{ if isset .Params "scope" }}
                 {{ $pageScopes := .Params.scope }}
-                {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}    
+                {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}
             {{ end }}
         {{ end }}
 
@@ -28,7 +29,7 @@
         {{ if $siteScopesEnabled }}
             {{ if isset .Params "scope" }}
                 {{ $pageScopes := .Params.scope }}
-                {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}    
+                {{ $isRendering = gt (len (intersect $pageScopes $siteScopes)) 0 }}
             {{ end }}
         {{ end }}
 


### PR DESCRIPTION
Expose the index.md file to WYSIWYG

### Description
Currently any content on the index.md files aren't editable by the WYSIWYG. This attempts to expose it, without fundamentally breaking the site.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3467

### Testing
Check that index.md files content looks fine and can be edited.

### Screenshots
N/A

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
