### PR TITLE
feat(search): Add article tags to searchmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,7 @@
 ## 2023-05-25
 ### Bugfixes
 - Fixed build error when archive age is set but maximum number of permitted archives to display is unset in site params @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3940
+
+## 2023-06-05
+### Updates
+- Added tags to search map. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3938

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -28,7 +28,7 @@
         {{ $scope = $scope | append .Params.Scope }}
     {{ end }}
     {{ if not (eq .Plain "") }}
-     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod  )}}
+     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" (.Params.tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod  )}}
     {{ end }}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
Adds frontmatter tags in to site searchmap

### Description
See [this PR](https://github.com/SPANDigital/presidium-services/pull/435) for context.

This adds frontmatter tags in to site searchmap.

### Issue
[PRSDM-3938](https://spandigital.atlassian.net/browse/PRSDM-3938)

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
