### PR TITLE
Fix menu carrot state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,7 @@
 ## 2023-06-05
 ### Updates
 - Added tags to search map. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3938
+
+## 2023-08-10
+### Bugfixes
+- Fixed the dropdown carrot state @meyerhp https://spandigital.atlassian.net/browse/PRSDM-4185

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,15 +1,25 @@
 <script>
-    $(document).ready(function () {
-        $('li.menu-row').not('.open').addClass('closed');
-        $('.menu-expander').click(function (event) {
-            event.preventDefault();
-            if (this.firstElementChild) {
-              this.firstElementChild.classList.toggle('glyphicon-chevron-down');
-              this.firstElementChild.classList.toggle('glyphicon-chevron-right');
-            }
-            $(this).parent().closest('.menu-row').toggleClass('open closed');
-        });
-    });
+  const toggleMenu = ($menu, isOpen) => {
+    $menu.toggleClass('open', isOpen).toggleClass('closed', !isOpen);
+    const $trigger = $menu.find('div.menu-expander > .glyphicon').first();
+    $trigger.toggleClass('glyphicon-chevron-down', isOpen).toggleClass('glyphicon-chevron-right', !isOpen);
+  };
+
+  $('li.menu-row').on('show.bs.collapse', (event) => {
+      event.stopPropagation();
+      const $menu = $(event.currentTarget);
+      toggleMenu($menu, true);
+  });
+
+  $('li.menu-row').on('hide.bs.collapse', (event) => {
+      event.stopPropagation();
+      const $menu = $(event.currentTarget);
+      toggleMenu($menu, false);
+  });
+
+  $('.menu-expander').click(function(event) {
+      event.preventDefault();
+  });
 </script>
 
 <script>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
This PR fixes the following issue:
> When opening a drop-down in Presidium (seen in both the Handbook and Chronicle, the carrot reverses itself, so it points down when closed and points to the side when opened (see image).

![Screenshot 2023-07-07 at 10 32 41 AM](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/f1315417-22e5-41fb-ae6d-0134bc689014)

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4185

### Testing
Try and break it.

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
