### PR TITLE
Set heading anchor offset to 50px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,9 @@
 ## 2023-06-05
 ### Updates
 - Added tags to search map. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-3938
+
+
+## 2023-08-10
+
+### Bug fixes
+- Fix anchor offset @meyerhp - https://spandigital.atlassian.net/browse/PRSDM-4246

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -76,8 +76,8 @@ html {
       span.anchor {
         display: block;
         position: relative;
-        top: -50px;
         visibility: hidden;
+        scroll-margin-top: 50px;
       }
 
       .article-title {
@@ -92,6 +92,7 @@ html {
         @include headings {
           margin: 0;
           padding: 0;
+          scroll-margin-top: 50px;
 
           &:hover {
             cursor: pointer;
@@ -284,6 +285,7 @@ html {
           text-transform: none;
           margin-top: 20px;
           margin-bottom: 10px;
+          scroll-margin-top: 50px;
         }
 
         .presidium-pro-tip,


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Updated the anchor offset to 50px for all headings and article titles. This will prevent the title from being hidden behind the toolbar.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4246

### Testing
Import the site into enterprise and make sure the offset works

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
