### PR TITLE
Add feedback feature to _index articles

### DIFF
--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -15,34 +15,36 @@
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}
 {{ $uid := .File.UniqueID }}
 
-<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}">
+<div class="article child {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}" >
     {{ if or (ne (len .Content) 0) (and $nestedArticles (partial "common/pages" .)) }}
         <div class="presidium-article-wrapper">
             <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>
+
             {{ partial "article/header" . }}
             {{ partial "article/title" . }}
             {{ partial "article/frontmatter" . }}
             {{ partial "article/content" . }}
             {{ partial "article/footer" . }}
+            {{ if or (not .Data.Pages) ($nestedArticles) }}
+                <hr>
+            {{ end }}
+        </div>
+    </div>
 
-            {{ if $nestedArticles }}
-                {{/* Sort by filename if specified in config */}}
-                {{ if .Site.Params.sortByFilePath }}
-                    {{/* Sort by file prefix */}}
-                    {{ range sort .Data.Pages "File.Path" }}
-                        {{ partial "article/root" . }}
-                    {{ end }}
-                {{ else }}
-                {{/* Sort by weight otherwise the hugo default */}}
-                {{ range .Data.Pages.ByWeight }}
-                    {{ partial "article/root" . }}
-                {{ end }}
+    {{ if $nestedArticles }}
+        {{/* Sort by filename if specified in config */}}
+        {{ if .Site.Params.sortByFilePath }}
+            {{/* Sort by file prefix */}}
+            {{ range sort .Data.Pages "File.Path" }}
+                {{ partial "article/root" . }}
+            {{ end }}
+        {{ else }}
+            {{/* Sort by weight otherwise the hugo default */}}
+            {{ range .Data.Pages.ByWeight }}
+                {{ partial "article/root" . }}
             {{ end }}
         {{ end }}
-
-        {{ if not .Data.Pages }}
-            <hr>
-        {{ end }}
-        </div>
     {{ end }}
+{{ else }}
 </div>
+{{ end }}

--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -15,7 +15,7 @@
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}
 {{ $uid := .File.UniqueID }}
 
-<div class="article child {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}" >
+<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}" >
     {{ if or (ne (len .Content) 0) (and $nestedArticles (partial "common/pages" .)) }}
         <div class="presidium-article-wrapper">
             <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>

--- a/layouts/partials/page/header.html
+++ b/layouts/partials/page/header.html
@@ -1,8 +1,19 @@
-<h1 class="page-title offendingHeading">
 {{ if eq (.Scratch.Get "scope") "single" }}
-    {{ .Parent.Title }}
+    <h1 class="page-title offendingHeading">
+        {{ .Parent.Title }}
+    </h1>
 {{ else }}
-    {{ .Title}}
+    {{ $roles := .Params.roles | default "All Roles" }}
+    {{ $pageLink :=  .Page.RelPermalink }}
+    {{ $articleId := .Params.id | default .File.Path }}
+    {{ $slug := (partial "common/slug" .) }}
+
+    <div class="page title" data-roles="{{ $roles }}" data-link="{{ $pageLink }}" permalink="{{ .Page.RelPermalink }}" data-disable-article-bar="true">
+        <div class="article-title article-actions" data-align="center-left">
+            <h1 class="page-title offendingHeading">
+                {{ .Title}}
+            </h1>
+        </div>
+    </div>
 {{ end }}
-</h1>
 <hr class="offendingHr" />

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -1,4 +1,18 @@
-{{.Content}}
+{{ if (ne (len .Content) 0) }}
+    {{ $roles := .Params.roles | default "All Roles" }}
+    {{ $uid := .File.UniqueID }}
+    {{ $articleId := .Params.id | default .File.Path }}
+    {{ $articleLink := (printf "%v#%v" .Parent.Page.RelPermalink ) }}
+    {{ $slug := (partial "common/slug" .) }}
+    <div class="article child" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{ .Page.RelPermalink }}">
+        <div class="presidium-article-wrapper">
+            <span class="anchor" id="{{ $slug }}" data-id="{{ $articleId }}"></span>
+            {{ .Content }}
+            <hr />
+        </div>
+    </div>
+{{ end }}
+
 {{ $pages := (partial "common/pages" .) }}
 {{ $siteScopes := .Site.Params.scopes }}
 {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -4,9 +4,11 @@
     {{ $articleId := .Params.id | default .File.Path }}
     {{ $articleLink := (printf "%v#%v" .Parent.Page.RelPermalink ) }}
     {{ $slug := (partial "common/slug" .) }}
-    <div class="article child" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{ .Page.RelPermalink }}">
+
+    <div class="article index" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{ .Page.RelPermalink }}">
         <div class="presidium-article-wrapper">
             <span class="anchor" id="{{ $slug }}" data-id="{{ $articleId }}"></span>
+            <div class="article-title article-actions" data-align="center-left"></div>
             {{ .Content }}
             <hr />
         </div>

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -1,19 +1,20 @@
-{{ if (ne (len .Content) 0) }}
-    {{ $roles := .Params.roles | default "All Roles" }}
-    {{ $uid := .File.UniqueID }}
-    {{ $articleId := .Params.id | default .File.Path }}
-    {{ $articleLink := (printf "%v#%v" .Parent.Page.RelPermalink ) }}
-    {{ $slug := (partial "common/slug" .) }}
+{{ $roles := .Params.roles | default "All Roles" }}
+{{ $uid := .File.UniqueID }}
+{{ $pageLink := .Page.RelPermalink }}
+{{ $articleId := .Params.id | default .File.Path }}
+{{ $slug := (partial "common/slug" .) }}
+{{ $disableArticleBar := (eq (len .Content) 0) }}
 
-    <div class="article index" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{ .Page.RelPermalink }}">
-        <div class="presidium-article-wrapper">
-            <span class="anchor" id="{{ $slug }}" data-id="{{ $articleId }}"></span>
-            <div class="article-title article-actions" data-align="center-left"></div>
-            {{ .Content }}
+<div class="page index" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $pageLink }}" permalink="{{ .Page.RelPermalink }}" data-disable-article-bar="{{ $disableArticleBar }}">
+    <div class="presidium-article-wrapper">
+        <span class="anchor" id="{{ $slug }}" data-id="{{ $articleId }}"></span>
+        {{ if (ne (len .Content) 0) }}
+            <article>{{ .Content }}</article>
             <hr />
-        </div>
+        {{ end }}
     </div>
-{{ end }}
+</div>
+
 
 {{ $pages := (partial "common/pages" .) }}
 {{ $siteScopes := .Site.Params.scopes }}


### PR DESCRIPTION

Add feedback feature to _index articles.


### Description
Add feedback feature to _index articles.
Add WYSIWYG editing to __index articles.

Wraps the content in the same div wrapper with data as  articles in `layouts/partials/article/root.html`

Requires [presidium-js-enterprise](https://github.com/SPANDigital/presidium-js-enterprise/pull/374) to enable feedback and editing.

### Issue
[PRSDM-3467](https://spandigital.atlassian.net/browse/PRSDM-3467)

### Testing
Load your test site that has an _index : eg  presidium-docs-internal > apple > common-tasks

### Screenshots
![image](https://github.com/SPANDigital/presidium-theme-website/assets/1186788/b17c3291-0ef9-45e2-ab43-869506cc0223)
### Checklist before merging

* [ ] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
