### PR TITLE
Use menu name if page name is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,3 +138,7 @@
 ### Bugfixes
 - Fixed the dropdown carrot state @meyerhp https://spandigital.atlassian.net/browse/PRSDM-4185
 - Fix anchor offset @meyerhp - https://spandigital.atlassian.net/browse/PRSDM-4246
+
+## 2023-09-12
+### Bugfixes
+- Display menu name if page name is not defined

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -1,6 +1,7 @@
 {{ $childLevel := add .Level 1 }}
 {{ $slugifyUrl := and .SlugifyUrl }}
 {{ $roles := .NavPage.Params.roles | default "All Roles" }}
+{{ $name := .NavPage.Name | default .MenuName }}
 {{/* rootUrl is the baseUrl but it defaults to "/" if no baseUrl is set */}}
 {{ $rootUrl := .RootUrl }}
 
@@ -51,7 +52,7 @@
                 </div>
             {{ end }}
             <div class="menu-title">
-                {{ partial "navigation/menu-title" .NavPage }}
+                {{ partial "navigation/menu-title" (dict "Name" $name) }}
             </div>
         </a>
         <div class="article-navbar-options" data-target="#{{$pageSlug}}"  data-id="{{ $articleId }}">

--- a/layouts/partials/navigation/root.html
+++ b/layouts/partials/navigation/root.html
@@ -46,7 +46,7 @@
                     {{ else }}
                         {{ $identifier := anchorize $menu.Identifier }}
                         {{ with $.Site.GetPage $identifier }}
-                            {{ partial "navigation/nav-item" (dict "NavPage" . "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed  "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}
+                            {{ partial "navigation/nav-item" (dict "NavPage" . "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed  "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}
                         {{ end }}
                     {{ end }}                    
                 {{ end }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
This PR updates the nav to use the name defined in the config menu if there is no "_index.md" with a section name. 

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4330

### Screenshots
![Screenshot 2023-09-12 at 14 29 06](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/20035bd9-113e-4647-9fdd-6f984108c5bf)


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
