### PR TITLE
Update external link layout and icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,3 +138,7 @@
 ### Bugfixes
 - Fixed the dropdown carrot state @meyerhp https://spandigital.atlassian.net/browse/PRSDM-4185
 - Fix anchor offset @meyerhp - https://spandigital.atlassian.net/browse/PRSDM-4246
+
+## 2023-09-12
+### Bugfixes
+- Fix styling and layout of external nav links

--- a/layouts/partials/navigation/nav-item-external.html
+++ b/layouts/partials/navigation/nav-item-external.html
@@ -1,9 +1,13 @@
-<li class="menu-parent_{{ .Identifier }}">
-    <div class="menu-row level-1">
-        <div class="menu-expander"></div>
-        <div class="menu-title">
-            {{ $newTab := .Params.externalUrl.newTab | default true }}
-            <a data-slug="{{ .Identifier }}" href="{{ .Params.externalUrl.href }}" target="{{ if $newTab }}_blank{{ end}}">{{ .Name }}</a>
-        </div>
+<li class="menu-row">
+    <div class="link level-1">
+        {{ $newTab := .Params.externalUrl.newTab | default true }}
+        <a class="level-1" href="{{ .Params.externalUrl.href }}" target="{{ if $newTab }}_blank{{ end}}">
+            <div class="menu-expander" data-toggle="collapse">
+                <span class="glyphicon glyphicon-new-window"></span>
+            </div>
+            <div class="menu-title">
+                {{ .Name }}
+            </div>
+        </a>
     </div>
 </li>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
This PR updates the layout for external links to ensure they are aligned with the rest of the menu.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4329

### Testing
Sample config
```
 - identifier: external-link
      name: External Link
      weight: 2
      params:
        externalUrl:
          href: "https://www.anothersite.com"
          newTab: true
```

### Screenshots
![Screenshot 2023-09-12 at 14 18 34](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/3488d627-0387-4458-8add-ba8f97d39e4b)

![Screenshot 2023-09-12 at 14 16 22](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/6edca7dc-89fb-417c-883c-d5c0e4fd69b5)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
