### PR TITLE
PRSDM-4416 - Scroll-spy not expanding menu on Apple site

### DIFF
--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -22,11 +22,11 @@
   });
 
   // Recursively open the current page's menu nav
-  let el = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
-  while (el.length) {
-      toggleMenu(el, true);
-      $(el).find('ul').first().toggleClass('in active');
-      el = el.parent().closest('.menu-row');
+  let navAnchor = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
+  while (navAnchor.length) {
+      toggleMenu(navAnchor, true);
+      $(navAnchor).find('ul').first().toggleClass('in active');
+      navAnchor = navAnchor.parent().closest('.menu-row');
   }
 
 </script>

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -20,6 +20,15 @@
   $('.menu-expander').click(function(event) {
       event.preventDefault();
   });
+
+  // Recursively open the current page's menu nav
+  let el = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
+  while (el.length) {
+      toggleMenu(el, true);
+      $(el).find('ul').first().toggleClass('in active');
+      el = el.parent().closest('.menu-row');
+  }
+
 </script>
 
 <script>

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -22,11 +22,11 @@
   });
 
   // Recursively open the current page's menu nav
-  let navAnchor = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
-  while (navAnchor.length) {
-      toggleMenu(navAnchor, true);
-      $(navAnchor).find('ul').first().toggleClass('in active');
-      navAnchor = navAnchor.parent().closest('.menu-row');
+  let navItem = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
+  while (navItem.length) {
+      toggleMenu(navItem, true);
+      $(navItem).find('ul').first().toggleClass('in active');
+      navItem = navItem.parent().closest('.menu-row');
   }
 
 </script>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Recursively open the menu item of the selected page

### Issue
[PRSDM-4416](https://spandigital.atlassian.net/browse/PRSDM-4416)

### Testing
Try the menu navigation, it should open on selected sections

### Screenshots

https://github.com/SPANDigital/presidium-theme-website/assets/34862470/88f82714-7f1d-4fd2-ba6d-83c0c201f79c


### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
