### PR TITLE
Improve page load by enabling preload and  reducing page shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,3 +143,8 @@
 ### Bugfixes
 - Display menu name if page name is not defined
 - Fix styling and layout of external nav links
+
+
+## 2023-10-06
+### Improvements
+= Optimize page load and reduce layout shift @meyerhp

--- a/assets/_sass/_default-variables.scss
+++ b/assets/_sass/_default-variables.scss
@@ -15,7 +15,7 @@ $color-yellow-green: #beb239;
 $color-green: #84a93f;
 $color-blue: #4586cd;
 $color-red: #e52213;
-$color-black: #3d3d3d;
+$color-dark-grey: #3d3d3d;
 // Fonts
 $primary-font-family: 'Gotham', sans-serif !default;
 

--- a/assets/_sass/_default-variables.scss
+++ b/assets/_sass/_default-variables.scss
@@ -15,7 +15,7 @@ $color-yellow-green: #beb239;
 $color-green: #84a93f;
 $color-blue: #4586cd;
 $color-red: #e52213;
-
+$color-black: #3d3d3d;
 // Fonts
 $primary-font-family: 'Gotham', sans-serif !default;
 

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -33,6 +33,8 @@ html {
   flex-direction: column;
 
   .toolbar-wrapper {
+    min-height: 50px;
+    background-color: $color-black;
     z-index: $zindex-navbar;
     position: sticky;
     position: sticky;

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -34,7 +34,7 @@ html {
 
   .toolbar-wrapper {
     min-height: 50px;
-    background-color: $color-black;
+    background-color: $color-dark-grey;
     z-index: $zindex-navbar;
     position: sticky;
     position: sticky;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     {{ hugo.Generator }}
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">
     {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
-    <link rel="preload" as="style" href="{{ $style.Permalink }}" as="style">
+    <link rel="preload" as="style" href="{{ $style.Permalink }}">
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">
     {{ if resources.Get "index.scss" }}
       {{ with resources.Get "index.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,14 +7,18 @@
     {{ hugo.Generator }}
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">
     {{ $style := resources.Get "presidium.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    <link rel="preload" as="style" href="{{ $style.Permalink }}" as="style">
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">
     {{ if resources.Get "index.scss" }}
       {{ with resources.Get "index.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
         <link rel="stylesheet" href="{{ .RelPermalink }}">
       {{ end }}
     {{ end }}
-    <script src="{{ "assets/scripts/jquery.js" | absURL }}"></script>
-    <script src="{{ "assets/scripts/bootstrap.js" | absURL }}"></script>
+
+    {{ if $.Site.Params.enterprise_enabled }}
+      <link rel="preload" src="/presidium-enterprise.js" as="script">
+    {{ end }}
+    
     {{ if $.Site.Params.lazyLoad }}
       {{ $url := urls.Parse .Site.BaseURL }}
       {{ $url = path.Clean $url.Path }}
@@ -35,7 +39,7 @@
       <div id="presidium-navigation">
         {{ if $.Site.Params.lazyLoad }}
           <script>
-            $('#presidium-navigation').html(window.navigation);
+            document.querySelector('#presidium-navigation').innerHTML = window.navigation;
           </script>
         {{ else }}
           {{ partialCached "navigation/root" . 0 }}
@@ -56,7 +60,7 @@
           </div>
       </div>
     </div>
- 
+
     {{ partialCached "page/modal" 0 }}
     {{ partialCached "page/script" . }}
     {{ if $.Site.Params.analyticsToken }}

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,3 +1,22 @@
+<script defer src="/presidium.js"></script>
+{{ if $.Site.Params.enterprise_enabled }}
+<script defer src="{{ $.Site.Params.enterprise_script }}"></script>
+<script>
+  const toolbarElement = document.querySelector('#presidium-enterprise');
+  const navigationElement = document.querySelector('#presidium-navigation');
+  if (toolbarElement) {
+      const toolbarHeight = toolbarElement.offsetHeight;
+      if (toolbarHeight) {
+          navigationElement.style.top = `${toolbarHeight}px`;
+      }
+  }
+</script>
+{{ end }}
+
+<script defer src="{{ "assets/scripts/jquery.js" | absURL }}"></script>
+<script defer src="{{ "assets/scripts/bootstrap.js" | absURL }}"></script>
+<script defer src={{ "assets/scripts/mermaid.js" | absURL }}></script>
+
 <script>
   const toggleMenu = ($menu, isOpen) => {
     $menu.toggleClass('open', isOpen).toggleClass('closed', !isOpen);
@@ -39,11 +58,9 @@
 </script>
 
 <!-- Components -->
-<script src={{ "assets/scripts/mermaid.js" | absURL }}></script>
-<script src="/presidium.js"></script>
 <script>
-    window.presidium.tooltips.load();
-    window.presidium.modal.init();
+    window.presidium?.tooltips.load();
+    window.presidium?.modal.init();
 
     mermaid.initialize({
         startOnLoad: true,
@@ -56,16 +73,6 @@
         },
     });
 </script>
-
-{{ if $.Site.Params.enterprise_enabled }}
-<script src="{{ $.Site.Params.enterprise_script }}"></script>
-<script>
-    const toolbarHeight = $("#presidium-enterprise").height()
-    if(toolbarHeight) {
-      $("#presidium-navigation").css({ top: `${toolbarHeight}px` });
-    }
-</script>
-{{ end }}
 
 {{ if $.Site.Params.resizeMenu | default true }}
 <script>

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,7 +1,7 @@
 <script defer src="/presidium.js"></script>
 {{ if $.Site.Params.enterprise_enabled }}
 <script defer src="{{ $.Site.Params.enterprise_script }}"></script>
-<script>
+<script type="module">
   const toolbarElement = document.querySelector('#presidium-enterprise');
   const navigationElement = document.querySelector('#presidium-navigation');
   if (toolbarElement) {
@@ -17,7 +17,7 @@
 <script defer src="{{ "assets/scripts/bootstrap.js" | absURL }}"></script>
 <script defer src={{ "assets/scripts/mermaid.js" | absURL }}></script>
 
-<script>
+<script type="module">
   const toggleMenu = ($menu, isOpen) => {
     $menu.toggleClass('open', isOpen).toggleClass('closed', !isOpen);
     const $trigger = $menu.find('div.menu-expander > .glyphicon').first();
@@ -48,34 +48,28 @@
       navItem = navItem.parent().closest('.menu-row');
   }
 
-</script>
-
-<script>
   function copyPermalink(link) {
       // Copy the article link to the clipboard
       navigator.clipboard.writeText(RegExp('^/*(.*)').exec(link)[1]);
   }
-</script>
 
-<!-- Components -->
-<script>
-    window.presidium?.tooltips.load();
-    window.presidium?.modal.init();
+  window.presidium?.tooltips.load();
+  window.presidium?.modal.init();
 
-    mermaid.initialize({
-        startOnLoad: true,
-        theme: 'base',
-        themeVariables: {
-            'primaryColor': '#00827E',
-            'primaryBorderColor': '#2C6764',
-            'secondaryColor': '#FFFFFF',
-            'lineColor': '#666',
-        },
-    });
+  mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+          'primaryColor': '#00827E',
+          'primaryBorderColor': '#2C6764',
+          'secondaryColor': '#FFFFFF',
+          'lineColor': '#666',
+      },
+  });
 </script>
 
 {{ if $.Site.Params.resizeMenu | default true }}
-<script>
+<script type="module">
     const desktopSize = window.matchMedia("(min-width: 768px)")
     const resizer = document.querySelector("#resizer");
     const sidebar = document.querySelector("#presidium-navigation");
@@ -107,8 +101,7 @@
 {{ end }}
 
 {{ if $.Site.Params.enableSublinks }}
-<script type="application/javascript">
-
+<script type="module">
   (function addHeadingLinks(){
     var articles = document.querySelectorAll('.article.child');
 


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
This PR improves the page load performance and reduces layout shift by optimizing the order in which we load scripts and styles. 

### Before:

 Lighthouse score | Render timeline  
:-------------------------:|:-------------------------:
![Screenshot 2023-10-06 at 17 53 32](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/67c34ab8-6ef8-44f4-b177-ca06f6966406) | ![Screenshot 2023-10-06 at 18 02 44](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/0e9c58f0-caae-41e0-9ca9-cc2ec59975d9)

### After:
 Lighthouse score | Render timeline  
:-------------------------:|:-------------------------:
![Screenshot 2023-10-06 at 17 55 05](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/1999f85e-bea4-4fac-a5bd-7066b39ecb63) | ![Screenshot 2023-10-06 at 17 59 19](https://github.com/SPANDigital/presidium-theme-website/assets/48946187/3e721862-8fd0-4137-92e7-4d55778bcc0f)

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4555

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
