### PR TITLE
Remove global font styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,3 +143,7 @@
 ### Bugfixes
 - Display menu name if page name is not defined
 - Fix styling and layout of external nav links
+
+## 2023-10-09
+### Bugfixes
+- Remove global font styles @meyerhp

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -23,10 +23,6 @@
   }
 }
 
-html {
-  font-size: 16px;
-}
-
 #presidium {
   display: flex;
   flex-flow: row;

--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -17,21 +17,6 @@
 }
 
 
-// Body reset
-
-html {
-  font-size: 10px;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-}
-
-body {
-  font-family: $font-family-base;
-  font-size: $font-size-base;
-  line-height: $line-height-base;
-  color: $text-color;
-  background-color: $body-bg;
-}
-
 // Reset fonts for relevant elements
 input,
 button,

--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -16,6 +16,13 @@
   @include box-sizing(border-box);
 }
 
+body {
+  font-family: $font-family-base;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
+  color: $text-color;
+  background-color: $body-bg;
+}
 
 // Reset fonts for relevant elements
 input,


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Removed the global font resets that are interfering with the enterprise styles.

See related PR https://github.com/SPANDigital/presidium-js-enterprise/pull/412

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4492


### Testing
<!-- Provide QA steps -->

### Screenshots

https://github.com/SPANDigital/presidium-theme-website/assets/48946187/fb2ae1d7-743f-4efd-a189-b2680862044e


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
