### PR TITLE
Fix global h tags in theme affecting enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,3 +151,7 @@
 ## 2023-10-06
 ### Improvements
 = Optimize page load and reduce layout shift @meyerhp
+
+## 2023-10-27
+### Updates
+- Fix global h tags in theme affecting enterprise. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4638

--- a/assets/_sass/bootstrap/bootstrap/_type.scss
+++ b/assets/_sass/bootstrap/bootstrap/_type.scss
@@ -5,50 +5,52 @@
 // Headings
 // -------------------------
 
-h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6 {
-  font-family: $headings-font-family;
-  font-weight: $headings-font-weight;
-  line-height: $headings-line-height;
-  color: $headings-color;
+.content-wrapper {
+  h1, h2, h3, h4, h5, h6,
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    font-family: $headings-font-family;
+    font-weight: $headings-font-weight;
+    line-height: $headings-line-height;
+    color: $headings-color;
 
-  small,
-  .small {
-    font-weight: normal;
-    line-height: 1;
-    color: $headings-small-color;
+    small,
+    .small {
+      font-weight: normal;
+      line-height: 1;
+      color: $headings-small-color;
+    }
   }
-}
 
-h1, .h1,
-h2, .h2,
-h3, .h3 {
-  margin-top: ($line-height-computed / 2);
-  margin-bottom: ($line-height-computed / 2);
+  h1, .h1,
+  h2, .h2,
+  h3, .h3 {
+    margin-top: ($line-height-computed / 2);
+    margin-bottom: ($line-height-computed / 2);
 
-  small,
-  .small {
-    font-size: 65%;
+    small,
+    .small {
+      font-size: 65%;
+    }
   }
-}
-h4, .h4,
-h5, .h5,
-h6, .h6 {
-  margin-top: 0;
-  margin-bottom: ($line-height-computed / 2);
+  h4, .h4,
+  h5, .h5,
+  h6, .h6 {
+    margin-top: 0;
+    margin-bottom: ($line-height-computed / 2);
 
-  small,
-  .small {
-    font-size: 75%;
+    small,
+    .small {
+      font-size: 75%;
+    }
   }
-}
 
-h1, .h1 { font-size: $font-size-h1; }
-h2, .h2 { font-size: $font-size-h2; }
-h3, .h3 { font-size: $font-size-h3; }
-h4, .h4 { font-size: $font-size-h4; }
-h5, .h5 { font-size: $font-size-h5; }
-h6, .h6 { font-size: $font-size-h6; }
+  h1, .h1 { font-size: $font-size-h1; }
+  h2, .h2 { font-size: $font-size-h2; }
+  h3, .h3 { font-size: $font-size-h3; }
+  h4, .h4 { font-size: $font-size-h4; }
+  h5, .h5 { font-size: $font-size-h5; }
+  h6, .h6 { font-size: $font-size-h6; }
+}
 
 
 // Body text


### PR DESCRIPTION
Fix global h tags in the theme affecting enterprise

### Description
Fix global h tags in the theme affecting enterprise

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4638

### Testing
Go to an article and open notifications. Notice the font.

Go to a dashboard page and open the notifications. Notice the font.

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
