### PR TITLE
Stringify Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,10 @@
 ### Bugfixes
 - Revert previous changes and apply fix in chronicle @kmorake https://spandigital.atlassian.net/browse/PRSDM-4681
 
+## 2023-11-28
+### Updates
+- Enable react routing between enterprise pages, while working with the static content. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4589
+
 ## 2024-01-10
 ### Updates
 - Added the Github team as the code owners @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4891
@@ -172,10 +176,6 @@
 ### Bugfixes
 - Fix Left Nav carrot error @WiaanBotha https://spandigital.atlassian.net/browse/PRSDM-4854
 - Add classname to index file content, for editor controls to target it. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4577
-
-## 2023-11-28
-### Updates
-- Enable react routing between enterprise pages, while working with the static content. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4589
 
 ## 2024-01-17
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,3 +171,24 @@
 ## 2024-01-04
 ### Bugfixes
 - Fix Left Nav carrot error @WiaanBotha https://spandigital.atlassian.net/browse/PRSDM-4854
+- Add classname to index file content, for editor controls to target it. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4577
+
+## 2023-11-28
+### Updates
+- Enable react routing between enterprise pages, while working with the static content. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-4589
+
+## 2024-01-17
+### Updates
+- Remove dead CSS classes after decoupling the WYSIWYG Editor. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-3945
+
+## 2024-01-30
+### New Feature
+- Added a new template to create a searchmap in the format required by the compendium. @kmorake https://spandigital.atlassian.net/browse/PRSDM-4966
+
+## 2024-02-02
+### bugfix
+- Added compendium output to the list of home outputs @kmorake https://spandigital.atlassian.net/browse/PRSDM-4966
+
+## 2024-02-06
+### bugfix
+- Updated the searchmap to converts tags to strings @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5056

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -29,7 +29,8 @@
     {{ end }}
     {{ if not (eq .Plain "") }}
      {{ $tags := apply .Params.tags "cast.ToString" "."}}
-     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod  )}}
+     {{ $summary := (index (split .Content "</p>") 0) | plainify  }}
+     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
     {{ end }}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -28,8 +28,8 @@
         {{ $scope = $scope | append .Params.Scope }}
     {{ end }}
     {{ if not (eq .Plain "") }}
-     {{ $summary := (index (split .Content "</p>") 0) | plainify  }}
-     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" (.Params.tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary )}}
+     {{ $tags := apply .Params.tags "cast.ToString" "."}}
+     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod  )}}
     {{ end }}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
The builder expects tags to be strings, currently the Chronicle build is failing because certain tags are not. I updated the template to cast all tags to strings

### Issue
https://spandigital.atlassian.net/browse/PRSDM-5056


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
