### PR TITLE
Remove config js script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,3 +195,7 @@
 ## 2024-02-06
 ### bugfix
 - Updated the searchmap to converts tags to strings @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5056
+
+## 2024-02-13
+### bugfix
+- Removed the config.js script from the theme @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5079

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,6 @@
     {{ end }}
 
     {{ if $.Site.Params.enterprise_enabled }}
-      <link rel="preload" src="/conf/config.js" as="script">
       <link rel="preload" src="/presidium-enterprise.js" as="script">
     {{ end }}
 

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,6 +1,5 @@
 <script defer src="/presidium.js"></script>
 {{ if $.Site.Params.enterprise_enabled }}
-<script src="/conf/config.js"></script>
 <script defer src="{{ $.Site.Params.enterprise_script }}"></script>
 <script type="module">
   const toolbarElement = document.querySelector('#presidium-enterprise');


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Removed the config.js script from the theme, it's been replaced with a config provider, see [here](https://github.com/SPANDigital/presidium-js-enterprise/pull/557)

### Issue
https://spandigital.atlassian.net/browse/PRSDM-5079

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
