### PR TITLE
Auto calculate 16:9 ratio for iframe width and height 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,3 +195,7 @@
 ## 2024-02-06
 ### bugfix
 - Updated the searchmap to converts tags to strings @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5056
+
+## 2024-02-16
+### bugfix
+- Calculate and set width and height for iframes @zelrestemmet https://spandigital.atlassian.net/browse/PRSDM-5061

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -286,6 +286,8 @@
         iframe {
           box-shadow: 0 0 10px #777;
           border: none;
+          width: 60vw !important; // 60% of the viewport because we have the left nav
+          height: calc(60vw*0.56) !important; // 16:9 aspect ratio
         }
 
         @include headings {


### PR DESCRIPTION
Auto calculate 16:9 ratio for iframe width and height 

### Description
Content creators need to explicitly add widths and heights to iframes.  Most content creators forget to add them and then the content of the iframe is not readable.

This fix auto calculates the width and height of the iframe, by setting the width to 60% of the viewport size (considering our left nav taking up space). The height is then calculated to a 16:9 aspect ratio of the width.

Viewport units are supported by the list of browsers we support: https://caniuse.com/viewport-units

### Issue
[<!-- JIRA link -->](https://spandigital.atlassian.net/browse/PRSDM-5061)

### Testing
Pull any module like SPAN handbook.  Pull this branch on `presidium-theme-website`, symlink the theme and run `hugo serve` on your module.  All iframes should be sized correctly.

### Screenshots
![Screenshot 2024-02-16 at 15 06 28](https://github.com/SPANDigital/presidium-theme-website/assets/10152442/e0c6bb62-809a-4406-bbee-23a7f1a90ce0)

### Checklist before merging
* [x ] Did you test your changes locally?
* [x ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
