### PR TITLE
Fix deprecated file usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,3 +195,7 @@
 ## 2024-02-06
 ### bugfix
 - Updated the searchmap to converts tags to strings @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5056
+
+## 2024-02-20
+### bugfix
+- Removed deprecated file params @meyerhp https://spandigital.atlassian.net/browse/PRSDM-5150

--- a/layouts/partials/common/filepath.html
+++ b/layouts/partials/common/filepath.html
@@ -1,0 +1,7 @@
+{{ $path := "" }}
+{{ with .File }}
+  {{ $path = .Path }}
+{{ else }}
+  {{ $path = .Path }}
+{{ end }}
+{{ return $path }}

--- a/layouts/partials/common/uuid.html
+++ b/layouts/partials/common/uuid.html
@@ -1,0 +1,7 @@
+{{ $uuid := "" }}
+{{ with .File }}
+  {{ $uuid = .UniqueID }}
+{{ else }}
+  {{ $uuid = md5 .Path }}
+{{ end }}
+{{ return $uuid }}

--- a/layouts/partials/page/header.html
+++ b/layouts/partials/page/header.html
@@ -5,7 +5,8 @@
 {{ else }}
     {{ $roles := .Params.roles | default "All Roles" }}
     {{ $pageLink :=  .Page.RelPermalink }}
-    {{ $articleId := .Params.id | default .File.Path }}
+    {{ $filePath := (partial "common/filepath" . ) }}
+    {{ $articleId := .Params.id | default $filePath }}
     {{ $slug := (partial "common/slug" .) }}
 
     <div class="page title" data-roles="{{ $roles }}" data-link="{{ $pageLink }}" permalink="{{ .Page.RelPermalink }}" data-disable-article-bar="true">

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -1,7 +1,7 @@
 {{ $roles := .Params.roles | default "All Roles" }}
-{{ $uid := .File.UniqueID }}
+{{ $uid := (partial "common/uuid" . ) }}
 {{ $pageLink := .Page.RelPermalink }}
-{{ $articleId := .Params.id | default .File.Path }}
+{{ $articleId := .Params.id | default (partial "common/filepath" .) }}
 {{ $slug := (partial "common/slug" .) }}
 {{ $disableArticleBar := (eq (len .Content) 0) }}
 


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
Removed the deprecated `File.Path` and `File.UniqueId` that are causing the build to fail with the latest Hugo version, replaced it with a shortcodes.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-5150

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [x] Is the documentation updated for this change? (If Required)
