### PR TITLE
PRSDMOn article summary in searchmap, pipe transform html unescape to summ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,3 +220,7 @@
 ## 2024-03-11
 ### Updates
 - Old fonts were removed and the portal theme was imported on the base docs html file, to make the fonts accessable from the docs. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-5185
+
+## 2024-04-19
+### Updates
+- On article summary in searchmap, pipe transform html unescape to summary to resolve issue of HTML special characters. @ChristopherBrunsdon https://spandigital.atlassian.net/browse/PRSDM-5538

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -28,7 +28,7 @@
         {{ $scope = $scope | append .Params.Scope }}
     {{ end }}
     {{ $tags := apply .Params.tags "cast.ToString" "."}}
-    {{ $summary := (index (split .Content "</p>") 0) | plainify  }}
+    {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}


### PR DESCRIPTION
…ary to resolve issue of HTML special characters.

<!-- PRS-123: Short description of change -->

### Description

Article summary was containing HTML special characters. Update to pipe Summary into htmlUnescape.

https://gohugo.io/functions/transform/htmlunescape/

### Issue
[PRSDM-5538](https://spandigital.atlassian.net/browse/PRSDM-5538)
### Testing
<!-- Provide QA steps -->

### Screenshots

In Action: 
<img width="369" alt="image" src="https://github.com/SPANDigital/presidium-theme-website/assets/1186788/5845d143-96b4-4aff-bb34-d9147d3a789d">

Original problem:

<img width="367" alt="image" src="https://github.com/SPANDigital/presidium-theme-website/assets/1186788/87d54d05-9032-478f-b728-5ef694999ae3">


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
