### PR TITLE
Change index page title to allow less confusion between pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>{{ $.Site.Title }}</title>
+    <title>{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ hugo.Generator }}
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">


### PR DESCRIPTION
### Description
I have updated the title page generated to allow for section - module in order to have less confusion when having multiple tabs open at different sections.

### Issue
[Thread](https://a1391190.slack.com/archives/G01DUF77HMX/p1719154838989849?thread_ts=1719022645.390519&cid=G01DUF77HMX)

### Testing
<!-- Provide QA steps -->

### Screenshots
![image](https://github.com/SPANDigital/presidium-theme-website/assets/110383881/d0b13c53-3e67-4b16-95e8-e6969bb12d2e)


### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
