### PR TITLE
PRSDM-6014: Adjusted the article options display to address overlapping

### DIFF
--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -375,11 +375,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         }
 
         .article-navbar-options {
-          margin-top: auto;
-          margin-bottom: auto;
-          position: absolute;
-          right: 10px;
-          top: 9px;
+          margin: auto 5px auto auto;
 
           .option-button {
             display: none;


### PR DESCRIPTION
### Description
Fixed the overlapping issue on the left nav for the article options display

### Issue
[PRSDM-6014](https://spandigital.atlassian.net/browse/PRSDM-6014)

### Screenshots

https://github.com/user-attachments/assets/7d3bb92b-ce14-42ba-9252-8a9e46c46651

### Checklist before merging

* [ ] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
