### PR TITLE
fix: set width to auto to fix images distortion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,3 +175,7 @@
 ## 2024-07-17
 ### Updates
 - Add resizer back. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-6012
+
+## 2024-08-01
+### Bugfixes
+- Fix images distortion. @julianbyte https://spandigital.atlassian.net/browse/PRSDM-6078

--- a/assets/_sass/_image.scss
+++ b/assets/_sass/_image.scss
@@ -2,7 +2,7 @@
   //Article Images
   img {
     max-width: 100% !important;
-    width: 100% !important;
+    width: auto;
     display: block;
     padding: 10px;
     margin: 10px auto 5px;


### PR DESCRIPTION
### Description
Set width to auto instead of 100% to fix images distortion

### Issue
[PRSDM-6078](https://spandigital.atlassian.net/browse/PRSDM-6078)

### Screenshots

Before:
![a3c49df4-1955-400d-bed2-53ce51684747](https://github.com/user-attachments/assets/e9ae1d66-a481-45f7-a520-648350c555e2)

After:
<img width="1440" alt="Screenshot 2024-08-01 at 15 16 07" src="https://github.com/user-attachments/assets/79bcc2e3-28ce-497b-9ff9-57a8ac903b2f">


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
