### PR TITLE
PRSDM-5995: Ensure that lower level article titles are not larger than higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,3 +175,7 @@
 ## 2024-07-17
 ### Updates
 - Add resizer back. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-6012
+
+## 2024-08-05
+### Bugfix
+- Ensure that lower level article titles are not larger than higher level articles @kmorake https://spandigital.atlassian.net/browse/PRSDM-5995

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -5,7 +5,7 @@
 {{/*  No title - For when the main title is the same as the first article  */}}
 {{ else }}
     <div class="article-title article-actions" data-align="center-left">
-        {{ if .Data.Pages }}
+        {{ if and (not .Data.Pages) (not .Parent) }}
             <h1> {{ .Title }}</h1>
         {{ else }}
             <h2> {{ .Title }}</h2>

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -5,7 +5,7 @@
 {{/*  No title - For when the main title is the same as the first article  */}}
 {{ else }}
     <div class="article-title article-actions" data-align="center-left">
-        {{ if and (not .Data.Pages) (not .Parent) }}
+        {{ if and (.Data.Pages) (not .Parent) }}
             <h1> {{ .Title }}</h1>
         {{ else }}
             <h2> {{ .Title }}</h2>


### PR DESCRIPTION
### Description
Ensure that lower level article titles are not larger than higher level articles

### Issue
[PRSDM-5995](https://spandigital.atlassian.net/browse/PRSDM-5995)

### Testing
<!-- Provide QA steps -->

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/2b555dad-c5dc-4345-bbd5-5345ec275203)

After:
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/2458174e-a6ef-42c5-ab63-743abbb7d24a">


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
