### PR TITLE
fix: add relative pos for pre and code to fix copy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,3 +244,7 @@
 ## 2024-07-29
 ### Features
 - Splitting of js & css build files. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-6018
+
+## 2024-08-05
+### Bugfix
+- Add relative position for pre and code to fix alignment issue with copy button on enterprise. @Zalaras https://spandigital.atlassian.net/browse/PRSDM-6124

--- a/assets/_sass/_default-fonts.scss
+++ b/assets/_sass/_default-fonts.scss
@@ -11,6 +11,7 @@ kbd,
 pre,
 samp {
   font-family: monospace !important;
+  position: relative;
 
   span {
     font-family: monospace !important;


### PR DESCRIPTION
### Description
Copy button of code block realigned to be in the code block instead of next to article title
Linked to: https://github.com/SPANDigital/presidium-js-enterprise/pull/681

### Issue
[PRSDM-6124](https://spandigital.atlassian.net/browse/PRSDM-6124)

### Testing
Build an enterprise site and find a codeblock

### Screenshots
![Screenshot 2024-08-05 at 23 20 24](https://github.com/user-attachments/assets/1399c18a-8cd7-47d4-bfb3-221fd2f5fa55)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
