### PR TITLE
fix: adjust line height for caret alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,3 +244,7 @@
 ## 2024-07-29
 ### Features
 - Splitting of js & css build files. @CharlRitterDev https://spandigital.atlassian.net/browse/PRSDM-6018
+
+## 2024-08-06
+### Bugfix
+- Update line-height of caret in the left nav menu to better align with link text. @Zalaras https://spandigital.atlassian.net/browse/PRSDM-6128

--- a/assets/_sass/_navbar.scss
+++ b/assets/_sass/_navbar.scss
@@ -282,6 +282,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
       span.glyphicon {
         padding: 4px;
         -webkit-text-stroke: 1px $navbar-default-bg;
+        line-height: 0.6;
 
         &:hover {
           background-color: $brand-tint;


### PR DESCRIPTION
### Description
Align caret better with the link text in the left nav

### Issue
[PRSDM-6128](https://spandigital.atlassian.net/browse/PRSDM-6128)

### Screenshots
Normal:
![Screenshot 2024-08-06 at 11 35 35](https://github.com/user-attachments/assets/888b6fad-790d-48e1-8157-9455a633bff6)
Zoomed:
![Screenshot 2024-08-06 at 11 31 07](https://github.com/user-attachments/assets/4637c1b2-0524-4fe0-85ab-65c5230ffe5a)

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
