### PR TITLE
refactor: Add horizontal scrollbar to code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,10 @@
 ### Fix
 - Added `aria-label` fields to articles for voice over functionality. @Quantumplate https://spandigital.atlassian.net/browse/PRSDM-6345
 
+## 2024-10-02
+### Refactor
+- Add horizontal scrollbar to code blocks. @julianbyte https://spandigital.atlassian.net/browse/PRSDM-5974
+
 ## 2024-10-03
 ### Bugfix
 - Set the width of the sidenav if there isn't one already set. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-6369

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -79,6 +79,7 @@
 }
 
 #presidium-container {
+  max-width: 100%;
   flex-basis: 0;
   flex-grow: 999;
   color: $gray-darker;

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -81,7 +81,8 @@
 #presidium-container {
   max-width: 100%;
   flex-basis: 0;
-  flex-grow: 999;
+  flex-grow: 1;
+  overflow-x: hidden;
   color: $gray-darker;
 
   .row {

--- a/assets/_sass/_syntax.scss
+++ b/assets/_sass/_syntax.scss
@@ -11,6 +11,7 @@ This is css for code highlighting.
 */
 .highlight {
   background: #fff;
+  position: relative;  /* Create a positioning context for the CopyCodeBlockButton */
 }
 
 .highlight .c {

--- a/assets/_sass/bootstrap/bootstrap/_code.scss
+++ b/assets/_sass/bootstrap/bootstrap/_code.scss
@@ -42,15 +42,18 @@ pre {
   background-color: $pre-bg;
   border: 1px solid $pre-border-color;
   border-radius: $border-radius-base;
+  overflow-x: auto;
+  width: 100%;
+  box-sizing: border-box;
 
   // Account for some code outputs that place code tags in pre tags
   code {
     padding: 0;
     font-size: inherit;
     color: inherit;
-    white-space: pre-wrap;
     background-color: transparent;
     border-radius: 0;
+    white-space: pre;
   }
 }
 

--- a/assets/_sass/bootstrap/bootstrap/_code.scss
+++ b/assets/_sass/bootstrap/bootstrap/_code.scss
@@ -36,24 +36,19 @@ pre {
   margin: 0 0 ($line-height-computed / 2);
   font-size: ($font-size-base - 1); // 14px to 13px
   line-height: $line-height-base;
-  word-break: break-all;
-  word-wrap: break-word;
   color: $pre-color;
   background-color: $pre-bg;
   border: 1px solid $pre-border-color;
   border-radius: $border-radius-base;
-  overflow-x: auto;
-  width: 100%;
-  box-sizing: border-box;
 
   // Account for some code outputs that place code tags in pre tags
   code {
     padding: 0;
     font-size: inherit;
     color: inherit;
+    white-space: pre;
     background-color: transparent;
     border-radius: 0;
-    white-space: pre;
   }
 }
 


### PR DESCRIPTION
### Description
Add horizontal scrollbar to code blocks

### Issue
[PRSDM-5974](https://spandigital.atlassian.net/browse/PRSDM-5974)

### Testing
* Use the branch `PRSDM-5974` on presidium-js-enterprise so the copy code button stays fixed (see https://github.com/SPANDigital/presidium-js-enterprise/pull/742)
* Pick a project and modify the theme import in `config.yml` to use the local version of presidium-theme-website
* Build the project
* Test

### Screenshots
https://github.com/user-attachments/assets/78c3dae3-d549-4253-8efe-1fcabc0c9e4e


### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
