### PR TITLE
fix: By checking for .File, you will only render articles, pages, and…

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,12 +1,22 @@
 {{ define "header" }}
-{{ .Scratch.Set "scope" "list" }}
-{{ partial "page/header" . }}
+    {{ .Scratch.Set "scope" "list" }}
+    {{ partial "page/header" . }}
 {{ end }}
 
 {{ define "content" }}
-    {{ partial "page/list" . }}
+
+    {{/*
+       * By checking for .File, you will only render articles, pages, and regular pages using the page/list partial.
+       * This will exclude tags, sections etc.  By doing this check here, it reduces the cause of exceptions later when
+       * calling attributes of .File later on, like .File.Path
+       */}}
+    {{ if .File }}
+        {{ partial "page/list" . }}
+    {{ else }}
+        {{ .Content }}
+    {{ end }}
 {{ end }}
 
 {{ define "footer" }}
-{{ partial "page/footer" . }}
+    {{ partial "page/footer" . }}
 {{ end }}


### PR DESCRIPTION
… regular pages using the page/list partial.  This will exclude tags, sections etc.  By doing this check here, it reduces the cause of exceptions later when calling attributes of .File later on, like .File.Path

<!-- PRS-123: Short description of change -->

### Description
<!-- A longer description of the change -->

### Issue
<!-- JIRA link -->

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
