### PR TITLE
fix: PRSDM-6121 articles need title field apple release

### DIFF
--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -15,7 +15,7 @@
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}
 {{ $uid := .File.UniqueID }}
 
-<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" permalink="{{.Page.RelPermalink}}" >
+<div class="article {{ $type }}" data-roles="{{ $roles }}" id="{{ $uid }}" data-link="{{ $articleLink }}" title="{{ .Title }}" permalink="{{.Page.RelPermalink}}" >
     {{ if or (ne (len .Content) 0) (and $nestedArticles (partial "common/pages" .)) }}
         <div class="presidium-article-wrapper">
             <span class="anchor"  id="{{ $slug }}" data-id="{{ $articleId }}"></span>


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
fix: PRSDM-6121 articles need title field for accessibility purposes in the apple release

### Description
<!-- A longer description of the change -->

### Issue
<!-- JIRA link -->
https://spandigital.atlassian.net/browse/PRSDM-6121

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
