### PR TITLE
feat: toc for pages

### DIFF
--- a/layouts/shortcodes/index-toc.html
+++ b/layouts/shortcodes/index-toc.html
@@ -1,0 +1,92 @@
+{{/*
+index-toc: shortcode for the table of contents of the pages for the current _index.
+Syntax: index-toc [depth=y default 1] [fullSite=true|false default false]
+    depth is the number of how many levels of subsections will be shown
+    fullSite is a boolean specifying if the ToC should be for the sections of the
+        entire site or only the sections for the current page
+
+    Generates a ToC for pages in the current section or all sections. When generating for
+    all sections the names of the sections index must match the names in the config.yml
+    otherwise it won't appear.
+
+    Example:
+    {{< index-toc >}}
+    or
+    {{< index-toc depth="2" >}}
+    or
+    {{< index-toc fullSite=true >}}
+    or
+    {{< index-toc fullSite=true depth="2" >}}
+*/}}
+
+{{ $depth :=  .Get "depth" | default 1 }}
+{{ $fullSite :=  .Get "fullSite" | default false }}
+
+<ul>
+    {{/* Show page ToC for entire site */}}
+    {{if $fullSite}}
+        {{/*
+            site.Sections ignores the weights specified in the config,
+            to get the sections in the correct order we have to loop through
+            the site menu object and add the section pages in that order
+        */}}
+        {{ $list := slice }}
+        {{ range site.Menus.main }}
+            {{ $item := . }}
+            {{ range site.Sections }}
+                {{/*
+                    If the section name matches the menu name we assume that it's a match
+                    This does mean that the name in the config should match the name of the
+                    sections .md file otherwise it won't show
+                */}}
+                {{ if eq .Title $item.Name }}
+                    {{ $list = $list | append . }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
+
+        {{ .Scratch.Set "pages" $list}}
+    {{/* Show page ToC current section only */}}
+    {{else}}
+        {{ .Scratch.Set "pages"  .Page.Pages.ByWeight }}
+    {{end}}
+    {{ $pages := (.Scratch.Get "pages") }}
+
+
+    {{/* Start the recursion to list the pages */}}
+    {{template "childs" dict
+                            "items" $pages
+                            "count" 1
+                            "depth" $depth
+                            "pages" $pages
+    }}
+</ul>
+
+{{ define "childs" }}
+    {{ range .items }}
+        <li>
+            <a href="{{ .RelPermalink }}" >{{ .Title }}</a>
+        </li>
+        {{ if lt $.count $.depth}}
+            <ul>
+
+                {{/* Get the subsections or pages for current page*/}}
+                {{ if .Sections}}
+                    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+                {{else}}
+                    {{ .Scratch.Set "pages" .Pages }}
+                {{end}}
+
+                {{ $pages := (.Scratch.Get "pages") }}
+
+                {{/* Continue with the recursion to list the pages */}}
+                {{template "childs" dict
+                                        "items" $pages.ByWeight
+                                        "count" (add $.count 1)
+                                        "depth" $.depth
+                                        "pages" $.pages
+                }}
+            </ul>
+        {{end}}
+    {{end}}
+{{end}}

--- a/layouts/shortcodes/index-toc.html
+++ b/layouts/shortcodes/index-toc.html
@@ -68,25 +68,28 @@ Syntax: index-toc [depth=y default 1] [fullSite=true|false default false]
             <a href="{{ .RelPermalink }}" >{{ .Title }}</a>
         </li>
         {{ if lt $.count $.depth}}
-            <ul>
 
-                {{/* Get the subsections or pages for current page*/}}
-                {{ if .Sections}}
-                    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
-                {{else}}
-                    {{ .Scratch.Set "pages" .Pages }}
-                {{end}}
+            {{/* Get the subsections or pages for current page*/}}
+            {{ if .Sections}}
+                {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+            {{else}}
+                {{ .Scratch.Set "pages" .Pages }}
+            {{end}}
 
-                {{ $pages := (.Scratch.Get "pages") }}
+            {{ $pages := (.Scratch.Get "pages") }}
 
-                {{/* Continue with the recursion to list the pages */}}
-                {{template "childs" dict
-                                        "items" $pages.ByWeight
-                                        "count" (add $.count 1)
-                                        "depth" $.depth
-                                        "pages" $.pages
-                }}
-            </ul>
+            {{ if $pages }}
+                <ul>
+
+                    {{/* Continue with the recursion to list the pages */}}
+                    {{template "childs" dict
+                                            "items" $pages.ByWeight
+                                            "count" (add $.count 1)
+                                            "depth" $.depth
+                                            "pages" $.pages
+                    }}
+                </ul>
+            {{end}}
         {{end}}
     {{end}}
 {{end}}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->

### Description
<!-- A longer description of the change -->
Shortcode to generate ToC of the pages for the current section or for the full site. 
Usage:
```
    {{< index-toc >}}
    or
    {{< index-toc depth="2" >}}
    or
    {{< index-toc fullSite=true >}}
    or
    {{< index-toc fullSite=true depth="2" >}}
```
`fullSite` - when true show ToC for entire site(all sections in navbar), otherwise it will only generate a ToC for the current section
`depth` - How many subsections should be included in ToC

*Note:* Only works when used in an _index.html file

### Issue
<!-- JIRA link -->
https://spandigital.atlassian.net/browse/PRSDM-6153

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->
`{{< index-toc >}}`:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/2625e37b-4f83-4f23-b7d7-7b098a08602f">

`{{< index-toc depth="2" >}}`:
<img width="801" alt="image" src="https://github.com/user-attachments/assets/24bf6cfe-14fe-4b4e-a1f3-d1795cb88206">

`{{< index-toc fullSite=true >}}`:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/0ff35be5-b374-4a86-bb91-99a9ebb5cd93">

`{{< index-toc fullSite=true depth="3">}}`:
<img width="815" alt="image" src="https://github.com/user-attachments/assets/9ab2a3c7-b840-427c-be01-90f426a68700">


### Checklist before merging

* [ ] Did you test your changes locally?
* [ ] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
