### PR TITLE
fix: set sidenav width if one does not exist PRSDM-6369

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,3 +270,7 @@
 ## 2024-09-17
 ### Fix
 - Added `aria-label` fields to articles for voice over functionality. @Quantumplate https://spandigital.atlassian.net/browse/PRSDM-6345
+
+## 2024-10-03
+### Bugfix
+- Set the width of the sidenav if there isn't one already set. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-6369

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -97,6 +97,11 @@
     const sidebar = document.querySelector("#presidium-navigation");
     const cachedSize = window.localStorage.getItem('sidenav');
 
+    if (cachedSize === null) {
+      window.localStorage.setItem('sidenav', '300px');
+      location.reload();
+    }
+
     if(desktopSize.matches) {
       resizer.style.display = 'block';
 


### PR DESCRIPTION
### Description
If a user has not set the width of the sidenav, the sidenav changes according to the size of the content. This fix sets the width of the sidenav if there isn't an existing width.

Below is a screen capture of the bug:

https://github.com/user-attachments/assets/7ea253d0-fd05-4900-a9f6-a521c8fe4a79

### Issue
https://spandigital.atlassian.net/browse/PRSDM-6369

### Testing
- In your local span-chronicle-docs repo, modify the theme import in config.yml to use the local version of presidium-theme-website
- Build SPAN Chronicle with presidium-content-builder
- Run presidium-js-enterprise
- Go to http://localhost:3000/docs/span-chronicle
- Open the Developer Tools and in the Application tab, select Storage > Local storage > http://localhost:3000
- If there is a sidenav key-value pair, delete it
- Reload the page and in the sidnav click the General Announcements dropdown and check that the sidenav width remains the same and doesn't shift

### Screenshots
https://github.com/user-attachments/assets/5ac51a77-264c-46eb-b630-c1109917da99

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
