### PR TITLE
feat: landing page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,3 +270,7 @@
 ## 2024-09-17
 ### Fix
 - Added `aria-label` fields to articles for voice over functionality. @Quantumplate https://spandigital.atlassian.net/browse/PRSDM-6345
+
+## 2024-10-07
+### Feature
+- Added rough layouts for rendering the proposed enterprise landing page. @Quantumplate 

--- a/layouts/landing/list.html
+++ b/layouts/landing/list.html
@@ -1,0 +1,11 @@
+{{ define "header" }}
+{{ .Scratch.Set "scope" "list" }}
+{{ partial "landing/header" . }}
+{{ end }}
+
+{{ define "content" }}
+{{ end }}
+
+{{ define "footer" }}
+{{ partial "landing/footer" . }}
+{{ end }}

--- a/layouts/landing/single.html
+++ b/layouts/landing/single.html
@@ -1,0 +1,11 @@
+{{ define "header" }}
+{{ .Scratch.Set "scope" "single" }}
+{{ partial "landing/header" . }}
+{{ end }}
+
+{{ define "content" }}
+{{ end }}
+
+{{ define "footer" }}
+{{ partial "landing/footer" . }}
+{{ end }}

--- a/layouts/partials/landing/footer.html
+++ b/layouts/partials/landing/footer.html
@@ -1,0 +1,7 @@
+{{ define "footer" }}
+<div class="landing-footer flex">
+    <h1>Landing Footer</h1>
+    <p>{{ .Content }}</p>
+    
+</div>
+{{ end }}

--- a/layouts/partials/landing/header.html
+++ b/layouts/partials/landing/header.html
@@ -1,0 +1,7 @@
+{{ define "header" }}
+<div class="landing-header flex">
+    <h1>Landing Header: {{.Title}}</h1>
+    <p>{{ .Description }}</p>
+   
+</div>
+{{ end }}


### PR DESCRIPTION
<!-- PRS-123: Short description of change -->
Added layouts to render basic landing page header and footer

### Description
<!-- A longer description of the change -->
Added layouts to render basic landing page header and footer for the content in https://github.com/SPANDigital/global-docs-landing
Still needs work, but should be enough to get us started.

### Issue
<!-- JIRA link -->

### Testing
<!-- Provide QA steps -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [x] Did you test your changes locally?
* [x] Did you update the CHANGELOG?
* [ ] Is the documentation updated for this change? (If Required)
