### PR TITLE
fix: Assign correct header to sub sections and articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,3 +287,7 @@
 ## 2024-11-04
 ### Fix
 - Fixes deprecation warnings for resources.ToCSS on layouts. @mpilo-khathwane https://spandigital.atlassian.net/browse/PRSDM-6522
+
+## 2024-11-07
+### Bugfix
+- Assign correct header to sub sections and articles. @julianbyte https://spandigital.atlassian.net/browse/PRSDM-6186

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -6,45 +6,18 @@
 {{ else }}
     <div class="article-title article-actions" data-align="center-left">
 
-        {{/* Calculate depth by counting parents, ignoring the global site title (`$.Site.Title`) to avoid an extra heading level */}}
+        {{/* Inline depth calculation using range to iterate up to max depth */}}
         {{ $depth := 0 }}
-        {{ $currentPage := . }}
+        {{ $parent := .Parent }}
+        {{ $maxDepth := 10 }} <!-- Set a maximum depth to prevent excessive iteration -->
 
-        {{ with $currentPage.Parent }}
-            {{ if ne .Title $.Site.Title }}
+        {{/* Use a range to simulate a loop up to maxDepth */}}
+        {{ range seq 1 $maxDepth }}
+            {{ if and $parent (ne $parent.Title $.Site.Title) }}
                 {{ $depth = add $depth 1 }}
-            {{ end }}
-            
-            {{ with .Parent }}
-                {{ if ne .Title $.Site.Title }}
-                    {{ $depth = add $depth 1 }}
-                {{ end }}
-                
-                {{ with .Parent }}
-                    {{ if ne .Title $.Site.Title }}
-                        {{ $depth = add $depth 1 }}
-                    {{ end }}
-                    
-                    {{ with .Parent }}
-                        {{ if ne .Title $.Site.Title }}
-                            {{ $depth = add $depth 1 }}
-                        {{ end }}
-                        
-                        {{ with .Parent }}
-                            {{ if ne .Title $.Site.Title }}
-                                {{ $depth = add $depth 1 }}
-                            {{ end }}
-                            
-                            {{ with .Parent }}
-                                {{ if ne .Title $.Site.Title }}
-                                    {{ $depth = add $depth 1 }}
-                                {{ end }}
-                                
-                                {{/* Add more nesting if your structure goes deeper */}}
-                            {{ end }}
-                        {{ end }}
-                    {{ end }}
-                {{ end }}
+                {{ $parent = $parent.Parent }}
+            {{ else }}
+                {{ break }}
             {{ end }}
         {{ end }}
 
@@ -55,22 +28,14 @@
         {{ end }}
 
         {{/* Output the heading tag based on calculated level */}}
-        {{ if eq $headingLevel 1 }}
-            <h1>{{ .Title }}</h1>
-        {{ else if eq $headingLevel 2 }}
-            <h2>{{ .Title }}</h2>
-        {{ else if eq $headingLevel 3 }}
-            <h3>{{ .Title }}</h3>
-        {{ else if eq $headingLevel 4 }}
-            <h4>{{ .Title }}</h4>
-        {{ else if eq $headingLevel 5 }}
-            <h5>{{ .Title }}</h5>
+        {{ if lt $headingLevel 6 }}
+            <h{{ $headingLevel }}>{{ .Title }}</h{{ $headingLevel }}>
         {{ else }}
             <h6>{{ .Title }}</h6>
         {{ end }}
 
         <div class="permalink">
-            <a style="cursor:pointer;" onclick="copyPermalink( {{ $articleLink }} )" id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}" class="link-icon" title="Permalink to this article"></a>
+            <a style="cursor:pointer;" onclick="copyPermalink('{{ $articleLink }}')" id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}" class="link-icon" title="Permalink to this article"></a>
         </div>
     </div>
 {{ end }}

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -2,17 +2,75 @@
 {{ $articleLink := ($.Scratch.Get "articleLink") }}
 
 {{ if (eq .Parent.Title .Title) }}
-{{/*  No title - For when the main title is the same as the first article  */}}
+{{/* No title - For when the main title is the same as the first article */}}
 {{ else }}
     <div class="article-title article-actions" data-align="center-left">
-        {{ if .Data.Pages }}
-            <h1> {{ .Title }}</h1>
+
+        {{/* Calculate depth by counting parents, ignoring the global site title (`$.Site.Title`) to avoid an extra heading level */}}
+        {{ $depth := 0 }}
+        {{ $currentPage := . }}
+
+        {{ with $currentPage.Parent }}
+            {{ if ne .Title $.Site.Title }}
+                {{ $depth = add $depth 1 }}
+            {{ end }}
+            
+            {{ with .Parent }}
+                {{ if ne .Title $.Site.Title }}
+                    {{ $depth = add $depth 1 }}
+                {{ end }}
+                
+                {{ with .Parent }}
+                    {{ if ne .Title $.Site.Title }}
+                        {{ $depth = add $depth 1 }}
+                    {{ end }}
+                    
+                    {{ with .Parent }}
+                        {{ if ne .Title $.Site.Title }}
+                            {{ $depth = add $depth 1 }}
+                        {{ end }}
+                        
+                        {{ with .Parent }}
+                            {{ if ne .Title $.Site.Title }}
+                                {{ $depth = add $depth 1 }}
+                            {{ end }}
+                            
+                            {{ with .Parent }}
+                                {{ if ne .Title $.Site.Title }}
+                                    {{ $depth = add $depth 1 }}
+                                {{ end }}
+                                
+                                {{/* Add more nesting if your structure goes deeper */}}
+                            {{ end }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
+
+        {{/* Set heading level based on depth, capping at 6 */}}
+        {{ $headingLevel := add $depth 1 }}
+        {{ if gt $headingLevel 6 }}
+            {{ $headingLevel = 6 }}
+        {{ end }}
+
+        {{/* Output the heading tag based on calculated level */}}
+        {{ if eq $headingLevel 1 }}
+            <h1>{{ .Title }}</h1>
+        {{ else if eq $headingLevel 2 }}
+            <h2>{{ .Title }}</h2>
+        {{ else if eq $headingLevel 3 }}
+            <h3>{{ .Title }}</h3>
+        {{ else if eq $headingLevel 4 }}
+            <h4>{{ .Title }}</h4>
+        {{ else if eq $headingLevel 5 }}
+            <h5>{{ .Title }}</h5>
         {{ else }}
-            <h2> {{ .Title }}</h2>
+            <h6>{{ .Title }}</h6>
         {{ end }}
 
         <div class="permalink">
-            <a id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}"></a>
+            <a style="cursor:pointer;" onclick="copyPermalink( {{ $articleLink }} )" id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}" class="link-icon" title="Permalink to this article"></a>
         </div>
     </div>
 {{ end }}

--- a/layouts/partials/article/title.html
+++ b/layouts/partials/article/title.html
@@ -28,11 +28,7 @@
         {{ end }}
 
         {{/* Output the heading tag based on calculated level */}}
-        {{ if lt $headingLevel 6 }}
-            <h{{ $headingLevel }}>{{ .Title }}</h{{ $headingLevel }}>
-        {{ else }}
-            <h6>{{ .Title }}</h6>
-        {{ end }}
+        <h{{ $headingLevel }}>{{ .Title }}</h{{ $headingLevel }}>
 
         <div class="permalink">
             <a style="cursor:pointer;" onclick="copyPermalink('{{ $articleLink }}')" id="{{.Page.RelPermalink}}" data-slug="#{{ $slug }}" class="link-icon" title="Permalink to this article"></a>


### PR DESCRIPTION
## Description
Updates the article title template to dynamically assign heading levels based on the article's depth in the content hierarchy. The depth calculation logic has been adjusted to skip the global site title ($.Site.Title), which Hugo treats as an implicit top-level parent. By ignoring this site title, the change prevents an extra heading level from being added and ensures that each article’s header level correctly reflects its actual position within the hierarchy.

## Issue
- [PRSDM-6186](https://spandigital.atlassian.net/browse/PRSDM-6186)

## Screenshots
Before:
<img width="1440" alt="Screenshot 2024-11-07 at 23 47 54" src="https://github.com/user-attachments/assets/3d082184-3c08-48a1-863b-407a99aa261e">

After:
<img width="1440" alt="Screenshot 2024-11-07 at 23 49 11" src="https://github.com/user-attachments/assets/d88312e9-910f-42f8-a5fc-9aea9b88aa69">

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
- [x] Changes were tested locally
